### PR TITLE
refactor(handler): Renaming `remove` to `deleteMarkedResource`

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
@@ -64,7 +64,7 @@ class AmazonLoadBalancerHandler(
   lockingService,
   retrySupport
 ) {
-  override fun remove(markedResource: MarkedResource, workConfiguration: WorkConfiguration) {
+  override fun deleteMarkedResource(markedResource: MarkedResource, workConfiguration: WorkConfiguration) {
     markedResource.resource.let { resource ->
       if (resource is AmazonElasticLoadBalancer && !workConfiguration.dryRun) {
         //TODO: consider also removing dns records for the ELB

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
@@ -58,7 +58,7 @@ class AmazonSecurityGroupHandler(
   lockingService,
   retrySupport
 ) {
-  override fun remove(markedResource: MarkedResource, workConfiguration: WorkConfiguration) {
+  override fun deleteMarkedResource(markedResource: MarkedResource, workConfiguration: WorkConfiguration) {
     markedResource.resource.let { resource ->
       if (resource is AmazonSecurityGroup && !workConfiguration.dryRun) {
         log.info("This resource is about to be deleted {}", markedResource)

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -49,6 +49,11 @@ abstract class AbstractResourceTypeHandler<out T : Resource>(
   private val resourceOwnerField: String = "swabbieResourceOwner"
 
   /**
+   * deletes a marked resource. Each handler must implement this function.
+   */
+  abstract fun deleteMarkedResource(markedResource: MarkedResource, workConfiguration: WorkConfiguration)
+
+  /**
    * finds & tracks cleanup candidates
    */
   override fun mark(workConfiguration: WorkConfiguration, postMark: () -> Unit) {
@@ -251,7 +256,7 @@ abstract class AbstractResourceTypeHandler<out T : Resource>(
             } else {
               if (r.notificationInfo != null && !workConfiguration.dryRun) {
                 retrySupport.retry({
-                  remove(r, workConfiguration)
+                  deleteMarkedResource(r, workConfiguration)
                 }, 3, 5000, true)
 
                 applicationEventPublisher.publishEvent(DeleteResourceEvent(r, workConfiguration))
@@ -359,6 +364,4 @@ abstract class AbstractResourceTypeHandler<out T : Resource>(
 
   private val Period.fromNow: LocalDate
     get() = LocalDate.now(clock) + this
-
-  abstract fun remove(markedResource: MarkedResource, workConfiguration: WorkConfiguration)
 }

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
@@ -347,7 +347,7 @@ object ResourceTypeHandlerTest {
     lockingService,
     retrySupport
   ) {
-    override fun remove(markedResource: MarkedResource, workConfiguration: WorkConfiguration) {
+    override fun deleteMarkedResource(markedResource: MarkedResource, workConfiguration: WorkConfiguration) {
       simulatedUpstreamResources?.removeIf { markedResource.resourceId == it.resourceId }
     }
 


### PR DESCRIPTION
- renamed remove function to be more descriptive