### PR TITLE
fix(mark): Should not mark a resource already marked

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/NotificationAgent.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/NotificationAgent.kt
@@ -51,12 +51,17 @@ class NotificationAgent(
 ) {
   @Value("\${swabbie.agents.notify.intervalSeconds:3600}")
   private var interval: Long = 3600
+
+  @Value("\${swabbie.agents.notify.delaySeconds:10}")
+  private var delay: Long = 10
+
   private val _lastAgentRun = AtomicReference<Instant>(clock.instant())
   private val lastNotifierAgentRun: Instant
     get() = _lastAgentRun.get()
 
   override fun getLastAgentRun(): Temporal? = lastNotifierAgentRun
   override fun getAgentFrequency(): Long = interval
+  override fun getAgentDelay(): Long = delay
   override fun getAction(): Action = Action.NOTIFY
   override fun initialize() {
     _lastAgentRun.set(clock.instant())

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceCleanerAgent.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceCleanerAgent.kt
@@ -53,12 +53,16 @@ class ResourceCleanerAgent(
   @Value("\${swabbie.agents.clean.intervalSeconds:3600}")
   private var interval: Long = 3600
 
+  @Value("\${swabbie.agents.clean.delaySeconds:5}")
+  private var delay: Long = 5
+
   private val _lastAgentRun = AtomicReference<Instant>(clock.instant())
   private val lastCleanerAgentRun: Instant
     get() = _lastAgentRun.get()
 
   override fun getLastAgentRun(): Temporal? = lastCleanerAgentRun
   override fun getAgentFrequency(): Long = interval
+  override fun getAgentDelay(): Long = delay
   override fun getAction(): Action = Action.DELETE
   override fun initialize() {
     _lastAgentRun.set(clock.instant())

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceMarkerAgent.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceMarkerAgent.kt
@@ -53,12 +53,16 @@ class ResourceMarkerAgent(
   @Value("\${swabbie.agents.mark.intervalSeconds:3600}")
   private var interval: Long = 3600
 
+  @Value("\${swabbie.agents.mark.delaySeconds:0}")
+  private var delay: Long = 0
+
   private val _lastAgentRun = AtomicReference<Instant>(clock.instant())
   private val lastMarkerAgentRun: Instant
     get() = _lastAgentRun.get()
 
   override fun getLastAgentRun(): Temporal? = lastMarkerAgentRun
   override fun getAgentFrequency(): Long = interval
+  override fun getAgentDelay(): Long = delay
   override fun getAction(): Action = Action.MARK
   override fun initialize() {
     _lastAgentRun.set(clock.instant())

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ScheduledAgent.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ScheduledAgent.kt
@@ -61,7 +61,7 @@ abstract class ScheduledAgent(
           )
         }
       }
-    }, 0, getAgentFrequency(), TimeUnit.SECONDS)
+    }, getAgentDelay(), getAgentFrequency(), TimeUnit.SECONDS)
   }
 
   override fun finalize(workConfiguration: WorkConfiguration) {
@@ -110,5 +110,6 @@ abstract class ScheduledAgent(
 
   abstract fun getLastAgentRun(): Temporal?
   abstract fun getAgentFrequency(): Long
+  abstract fun getAgentDelay(): Long
   abstract fun getAction(): Action
 }


### PR DESCRIPTION
- fixed an issue where a candidate would be marked over and over
- refactored scheduled agent to add a delay
- refactored lock key to only consider work namespace