### PR TITLE
refactor(*): Add basic support for batching deletes

### DIFF
--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
@@ -141,7 +141,14 @@ object AmazonImageHandlerTest {
   @AfterEach
   fun cleanup() {
     validateMockitoUsage()
-    reset(imageProvider, accountProvider, instanceProvider, launchConfigurationProvider, applicationEventPublisher)
+    reset(
+      resourceRepository,
+      imageProvider,
+      accountProvider,
+      instanceProvider,
+      launchConfigurationProvider,
+      applicationEventPublisher
+    )
   }
 
   @Test


### PR DESCRIPTION
- leveraging a channel to pass deleted resources for further processing
- partitioning the list of items to delete based on configuration
- updated test to state invocation times rather than an upper limit
- This paves the way for a PR to update Image handler to batch deletes