### PR TITLE
fix(exclusions): Should resolve owners before running exclusion policies

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -151,12 +151,12 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
       totalResourcesVisitedCounter.set(candidates.size)
 
       preProcessCandidates(
-        candidates.filter {
-          !shouldExcludeResource(it, workConfiguration, optedOutResourceStates, Action.MARK)
-        },
+        candidates
+          .withResolvedOwners(workConfiguration).filter {
+            !shouldExcludeResource(it, workConfiguration, optedOutResourceStates, Action.MARK)
+          },
         workConfiguration
-      ).withResolvedOwners(workConfiguration)
-        .let { filteredCandidates ->
+      ).let { filteredCandidates ->
           val maxItemsToProcess = Math.min(filteredCandidates.size, workConfiguration.maxItemsProcessedPerCycle)
 
           // list of currently marked & stored resources


### PR DESCRIPTION
- this fixes a regression due to refactoring
- need to be able to exclude/whitelist by owner
- to allow exclusion/inclusion by resource owner, that field needs to be computed before applying policies