### PR TITLE
feat(krieger): Augment owner resolution strategy with krieger

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,7 @@ include 'swabbie-test',
   'swabbie-clouddriver',
   'swabbie-front50',
   'swabbie-edda',
+  'swabbie-krieger',
   'swabbie-web'
 
 def setBuildFile(project) {

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/exclusions/ExclusionPolicy.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/exclusions/ExclusionPolicy.kt
@@ -77,7 +77,8 @@ interface ExclusionPolicy {
   fun findProperty(excludable: Excludable, key: String, values: List<String>): String? {
     try {
       val fieldValue = getProperty(excludable, key) as? String
-      if (values.contains(fieldValue) || values.any { fieldValue != null && fieldValue.matchPattern(it) }) {
+      if (values.contains(fieldValue) || values.any {
+          fieldValue != null && (fieldValue.matchPattern(it) || fieldValue.split(",").contains(it)) }) {
         return fieldValue
       }
     } catch (e: IllegalArgumentException) {

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
@@ -271,7 +271,7 @@ object ResourceTypeHandlerTest {
       retrySupport = retrySupport
     )
 
-    whenever(ownerResolver.resolve(resource1)) doReturn  "lucious-mayweather@netflix.com"
+    whenever(ownerResolver.resolve(resource1)) doReturn  "lucious-mayweather@netflix.com, quincy-polaroid@netflix.com"
     whenever(ownerResolver.resolve(resource2)) doReturn  "blah" // excluded because not in allowed list
 
     handler.mark(workConfiguration = configuration, postMark = { postAction(listOf(resource1, resource2)) })

--- a/swabbie-front50/src/main/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategy.kt
+++ b/swabbie-front50/src/main/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategy.kt
@@ -19,16 +19,124 @@ package com.netflix.spinnaker.swabbie.front50
 import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer
 import com.netflix.spinnaker.swabbie.InMemoryCache
 import com.netflix.spinnaker.swabbie.ResourceOwnerResolutionStrategy
+import com.netflix.spinnaker.swabbie.krieger.KriegerService
 import com.netflix.spinnaker.swabbie.model.Application
 import com.netflix.spinnaker.swabbie.model.Resource
 import org.springframework.stereotype.Component
 
 @Component
 class ApplicationResourceOwnerResolutionStrategy(
-  private val front50ApplicationCache: InMemoryCache<Application>
+  private val front50ApplicationCache: InMemoryCache<Application>,
+  private val kriegerApplicationCache: InMemoryCache<Application>
 ) : ResourceOwnerResolutionStrategy<Resource> {
-  override fun resolve(resource: Resource): String? =
-    FriggaReflectiveNamer().deriveMoniker(resource).app?.let { derivedApp ->
-      front50ApplicationCache.get().find { it.name.equals(derivedApp, ignoreCase = true) }?.email
+  override fun resolve(resource: Resource): String? {
+    // krieger returns applications with relationships to other resources: images, launch configs...
+    // Using a mapping to swabbie types to adapt to general use case. Krieger not required for this resolution to work.
+
+    // 1. Find applications from Krieger containing a reference to this resource.
+    val applicationToOwnersPairs = mutableSetOf<Pair<String?, String?>>()
+    if (resource.resourceType in KriegerService.kriegerFieldsToSwabbieTypes) {
+      KriegerService.kriegerFieldsToSwabbieTypes[resource.resourceType]!!.let { kriegerFieldAndTypePair ->
+        kriegerApplicationCache.get().filter { application ->
+          application.details[kriegerFieldAndTypePair.first] != null
+        }.map { application ->
+
+          // 2. Extract owner information for every matched application. Handle primitive & non-primitive relationships
+          getKriegerPotentialOwnersOrNull(application)?.let { potentialOwners ->
+            when {
+              kriegerFieldAndTypePair.second == Collection::class.java ->
+                (application.details[kriegerFieldAndTypePair.first]!! as Collection<*>).let { interestingObjects ->
+                  when {
+                    resource.resourceType in KriegerService.swabbieTypesTokriegerIdentifiableFields -> {
+                      val interestingId = KriegerService
+                        .swabbieTypesTokriegerIdentifiableFields[resource.resourceType]!!
+
+                      interestingObjects.any {
+                        it is Map<*, *> && resource.resourceId == it[interestingId]
+                      }.let { isInterestingApplication ->
+                        if (isInterestingApplication) {
+                          log.debug("resolved {} owners from Krieger application {}", resource.resourceId, application)
+                          applicationToOwnersPairs.add(Pair(application.name, potentialOwners))
+                        }
+                      }
+                    }
+
+                    interestingObjects.contains(resource.resourceId) -> {
+                      log.debug("resolved {} owners from Krieger application {}", resource.resourceId, application)
+                      applicationToOwnersPairs.add(Pair(application.name, potentialOwners))
+                    }
+                    else -> log.debug("No matched owners found in Krieger for {}", resource)
+                  }
+                }
+
+              kriegerFieldAndTypePair.second == String::class.java -> {
+                log.debug("resolved {} owners from Krieger application {}", resource.resourceId, application)
+                applicationToOwnersPairs.add(Pair(application.name, potentialOwners))
+              }
+              else -> {
+                log.debug("No matched owners found in Krieger for {} using type {}",
+                  resource, kriegerFieldAndTypePair)
+              }
+            }
+          }
+
+          applicationToOwnersPairs
+        }
+      }
     }
+
+    // 3. Derive object's moniker to find matching front50 apps.
+    FriggaReflectiveNamer().deriveMoniker(resource).app?.let { derivedApp ->
+      front50ApplicationCache.get().filter { application ->
+        application.monikerMatched(applicationToOwnersPairs, derivedApp)
+      }.map { application ->
+        log.debug("resolved {} owners from front50 application {}", resource.resourceId, application)
+        applicationToOwnersPairs.add(Pair(application.name, application.email))
+      }
+    }
+
+    // 4. Massage result by filtering out misses.
+    applicationToOwnersPairs.removeIf { it.first == null || it.second == null }
+    if (applicationToOwnersPairs.isEmpty()) {
+      log.debug("No matched owners with strategy {} for resoure {}", javaClass.simpleName, resource)
+      return null
+    }
+
+    // Join matches with ","
+    return applicationToOwnersPairs.map {
+      it.second
+    }.joinToString(",")
+  }
+
+  /**
+   * Matches an app by name. Skip memoized items
+   */
+  private fun Application.monikerMatched(
+    computedMatches: MutableSet<Pair<String?, String?>>,
+    moniker: String
+  ): Boolean {
+    return !computedMatches.any {
+      it.first.equals(name, true)
+    } && name.equals(moniker, ignoreCase = true)
+  }
+
+  /**
+   * Returns a list of comma separated owners if found or null
+   */
+  private fun getKriegerPotentialOwnersOrNull(application: Application): String? {
+    mutableSetOf(
+      application.email,
+      (application.details["declaredOwner"] as? Map<*, *>)?.get("email") as? String,
+      (application.details["owners"] as? List<*>)?.joinToString(","),
+      (application.details["contacts"] as? List<*>)?.joinToString(",")
+    ).apply {
+      remove(null)
+    }.let {
+      return if (it.isNotEmpty()) {
+        it.joinToString(",")
+      } else {
+        null
+      }
+    }
+  }
 }

--- a/swabbie-front50/src/test/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategyTest.kt
+++ b/swabbie-front50/src/test/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategyTest.kt
@@ -21,33 +21,81 @@ import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.should.shouldMatch
 import com.netflix.spinnaker.swabbie.InMemoryCache
 import com.netflix.spinnaker.swabbie.model.Application
+import com.netflix.spinnaker.swabbie.model.IMAGE
 import com.netflix.spinnaker.swabbie.model.Resource
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 object ApplicationResourceOwnerResolutionStrategyTest {
   private val front50ApplicationCache: InMemoryCache<Application> = mock()
-  private val subject = ApplicationResourceOwnerResolutionStrategy(front50ApplicationCache)
+  private val kriegerApplicationCache: InMemoryCache<Application> = mock()
+  private val subject = ApplicationResourceOwnerResolutionStrategy(front50ApplicationCache, kriegerApplicationCache)
 
   @Test
-  fun `should resolve resource owner from application config`() {
+  fun `should resolve resource owner from spinnaker application`() {
     whenever(front50ApplicationCache.get()) doReturn
       setOf(
         Application(name = "name", email = "name@netflix.com"),
         Application(name = "test", email = "test@netflix.com")
       )
 
-    subject.resolve(R()) shouldMatch equalTo("name@netflix.com")
+    subject.resolve(ResourceOne()) shouldMatch equalTo("name@netflix.com")
+  }
+
+  @Test
+  fun `should resolve resource owner from krieger application`() {
+    whenever(front50ApplicationCache.get()) doReturn
+      setOf(
+        Application(name = "blahApp", email = "name@netflix.com"),
+        Application(name = "testApp", email = "test@netflix.com")
+      )
+
+    // krieger applications have relationships to other resources. ie: images associated with this applications
+    whenever(kriegerApplicationCache.get()) doReturn
+      setOf(
+        Application(name = "randomApplication", email = "kriegerOwner@netflix.com").apply {
+          set("images", listOf(mapOf("id" to "ami-123")))
+        },
+        Application(name = "randomApplication 2", email = "test@netflix.com")
+      )
+
+    subject.resolve(ResourceTwo()) shouldMatch equalTo("kriegerOwner@netflix.com")
+    Assertions.assertNull(subject.resolve(ResourceOne()))
+  }
+
+  @Test
+  fun `should resolve all resource owners matched from a list of apps`() {
+    whenever(kriegerApplicationCache.get()) doReturn
+      setOf(
+        Application(name = "randomApplication", email = "kriegerOwner@netflix.com").apply {
+          set("images", listOf(mapOf("id" to "ami-123")))
+        },
+        Application(name = "randomApplication 2", email = "test@netflix.com").apply {
+          set("images", listOf(mapOf("id" to "ami-123")))
+        }
+      )
+
+    subject.resolve(ResourceTwo()) shouldMatch equalTo("kriegerOwner@netflix.com,test@netflix.com")
   }
 }
 
 @JsonTypeName("R")
-data class R(
+data class ResourceOne(
   override val resourceId: String = "id",
   override val name: String = "name",
   override val resourceType: String = "type",
+  override val cloudProvider: String = "provider",
+  override val createTs: Long = System.currentTimeMillis()
+) : Resource()
+
+@JsonTypeName("R")
+data class ResourceTwo(
+  override val resourceId: String = "ami-123",
+  override val name: String = "amiName",
+  override val resourceType: String = IMAGE,
   override val cloudProvider: String = "provider",
   override val createTs: Long = System.currentTimeMillis()
 ) : Resource()

--- a/swabbie-front50/swabbie-front50.gradle
+++ b/swabbie-front50/swabbie-front50.gradle
@@ -17,6 +17,7 @@
 dependencies {
   compile project(":swabbie-retrofit")
   compile project(":swabbie-core")
+  compile project(":swabbie-krieger")
 
   testCompile project(":swabbie-test")
   testCompile "com.squareup.retrofit:retrofit-mock:1.9.+"

--- a/swabbie-krieger/src/main/kotlin/com/netflix/spinnaker/config/KriegerConfiguration.kt
+++ b/swabbie-krieger/src/main/kotlin/com/netflix/spinnaker/config/KriegerConfiguration.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.swabbie.krieger.KriegerService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import retrofit.Endpoint
+import retrofit.Endpoints
+import retrofit.RequestInterceptor
+import retrofit.RestAdapter
+import retrofit.client.Client
+import retrofit.converter.JacksonConverter
+
+@Configuration
+@Import(RetrofitConfiguration::class)
+@ComponentScan("com.netflix.spinnaker.swabbie.krieger")
+open class KriegerConfiguration {
+  @Bean
+  open fun kriegerEndpoint(@Value("\${krieger.baseUrl:none}") kriegerBaseUrl: String): Endpoint
+    = Endpoints.newFixedEndpoint(kriegerBaseUrl)
+
+  @Bean
+  @ConditionalOnExpression("\${krieger.enabled:false}")
+  open fun kriegerService(kriegerEndpoint: Endpoint,
+                          objectMapper: ObjectMapper,
+                          retrofitClient: Client,
+                          spinnakerRequestInterceptor: RequestInterceptor,
+                          retrofitLogLevel: RestAdapter.LogLevel): KriegerService
+    = RestAdapter.Builder()
+    .setRequestInterceptor(spinnakerRequestInterceptor)
+    .setEndpoint(kriegerEndpoint)
+    .setClient(retrofitClient)
+    .setLogLevel(retrofitLogLevel)
+    .setConverter(JacksonConverter(objectMapper))
+    .build()
+    .create(KriegerService::class.java)
+}
+

--- a/swabbie-krieger/src/main/kotlin/com/netflix/spinnaker/swabbie/krieger/KriegerApplicationService.kt
+++ b/swabbie-krieger/src/main/kotlin/com/netflix/spinnaker/swabbie/krieger/KriegerApplicationService.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.swabbie.krieger
+
+import com.netflix.spinnaker.swabbie.InMemoryCache
+import com.netflix.spinnaker.swabbie.model.Application
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class KriegerApplicationService(
+  private val kriegerService: Optional<KriegerService>
+) {
+  private val log: Logger = LoggerFactory.getLogger(javaClass)
+  fun getApplications(): Set<Application> {
+    if (kriegerService.isPresent) {
+      return kriegerService.get()
+        .getApplications()
+        ._embedded["applications"]
+        .orEmpty()
+        .toSet()
+    }
+
+    log.debug("KRIEGER not enabled!!")
+    return emptySet()
+  }
+}
+
+@Component
+class KriegerApplicationCache(
+  kriegerApplicationService: KriegerApplicationService
+) : InMemoryCache<Application>(
+  kriegerApplicationService.getApplications()
+)
+

--- a/swabbie-krieger/src/main/kotlin/com/netflix/spinnaker/swabbie/krieger/KriegerService.kt
+++ b/swabbie-krieger/src/main/kotlin/com/netflix/spinnaker/swabbie/krieger/KriegerService.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.swabbie.krieger
+
+import com.netflix.spinnaker.swabbie.model.Application
+import com.netflix.spinnaker.swabbie.model.IMAGE
+import com.netflix.spinnaker.swabbie.model.LAUNCH_CONFIGURATION
+import com.netflix.spinnaker.swabbie.model.SERVER_GROUP
+import retrofit.http.GET
+
+interface KriegerService {
+  @GET("/api/applications")
+  fun getApplications(): ResolvedApplicationResponse
+
+  companion object {
+    val kriegerFieldsToSwabbieTypes = mapOf(
+      IMAGE to Pair("images", Collection::class.java),
+      LAUNCH_CONFIGURATION to Pair("launchConfigNames", Collection::class.java),
+      SERVER_GROUP to Pair("asgNames", Collection::class.java)
+    )
+
+    val swabbieTypesTokriegerIdentifiableFields = mapOf(
+      IMAGE to "id"
+    )
+  }
+}
+
+data class ResolvedApplicationResponse(
+  val _embedded: Map<String, List<Application>>
+)

--- a/swabbie-krieger/swabbie-krieger.gradle
+++ b/swabbie-krieger/swabbie-krieger.gradle
@@ -14,19 +14,8 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.swabbie.model
-
-import com.netflix.spinnaker.swabbie.Cacheable
-import com.netflix.spinnaker.swabbie.exclusions.Excludable
-
-data class Application(
-  val email: String?,
-  override val name: String
-) : HasDetails(), Cacheable, Excludable {
-  override val resourceId: String
-    get() = name
-  override val resourceType: String
-    get() = "application"
-  override val cloudProvider: String
-    get() = "*"
+dependencies {
+  compile project(":swabbie-core")
+  compile project(":swabbie-retrofit")
+  compile "com.netflix.spinnaker.moniker:moniker:+"
 }


### PR DESCRIPTION
- Added new module `swabbie-krieger` (can be in -nflx)
- Update owner resolution to return a comma delimited owners
- comma delimited owners ensures we dont miss an owner in strategies
- prefer notifying a group to only notifying a subset if there are > 1 owners