### PR TITLE
feat(controller): slim for resources/marked exists as default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.parallel=true
 
-kotlinVersion=1.2.21
+kotlinVersion=1.2.61
 jacksonVersion=2.9.4
 jackson.version=2.9.4

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
@@ -105,20 +105,60 @@ interface Timestamped {
   val createTs: Long
 }
 
+interface MarkedResourceInterface : Identifiable {
+  val summaries: List<Summary>
+  val namespace: String
+  var projectedDeletionStamp: Long
+  var notificationInfo: NotificationInfo?
+  var markTs: Long?
+  var updateTs: Long?
+  val resourceOwner: String
+}
+
 /**
  * Cleanup candidate decorated with additional metadata
  * 'projectedDeletionStamp' is the scheduled deletion time
  */
 data class MarkedResource(
   val resource: Resource,
-  val summaries: List<Summary>,
-  val namespace: String,
-  var projectedDeletionStamp: Long,
-  var notificationInfo: NotificationInfo? = null,
-  var markTs: Long? = null,
-  var updateTs: Long? = null,
-  val resourceOwner: String = ""
-) : Identifiable by resource
+  override val summaries: List<Summary>,
+  override val namespace: String,
+  override var projectedDeletionStamp: Long,
+  override var notificationInfo: NotificationInfo? = null,
+  override var markTs: Long? = null,
+  override var updateTs: Long? = null,
+  override val resourceOwner: String = ""
+) : MarkedResourceInterface, Identifiable by resource {
+  fun slim(): SlimMarkedResource {
+    return SlimMarkedResource(
+      summaries,
+      namespace,
+      projectedDeletionStamp,
+      notificationInfo,
+      markTs,
+      updateTs,
+      resourceOwner,
+      resource.resourceId,
+      resource.resourceType,
+      resource.cloudProvider,
+      resource.name
+    )
+  }
+}
+
+data class SlimMarkedResource (
+  override val summaries: List<Summary>,
+  override val namespace: String,
+  override var projectedDeletionStamp: Long,
+  override var notificationInfo: NotificationInfo? = null,
+  override var markTs: Long? = null,
+  override var updateTs: Long? = null,
+  override val resourceOwner: String = "",
+  override val resourceId: String,
+  override val resourceType: String,
+  override val cloudProvider: String,
+  override val name: String?
+) : MarkedResourceInterface
 
 data class NotificationInfo(
   val recipient: String? = null,

--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
@@ -32,15 +32,23 @@ class ResourceController(
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val workConfigurations: List<WorkConfiguration>
   ) {
+
   @RequestMapping(value = ["/marked"], method = [RequestMethod.GET])
   fun markedResources(
-    @RequestParam(required = false) expand: Boolean?
+    @RequestParam(required = false, defaultValue = "false") expand: Boolean
   ): List<MarkedResourceInterface> {
-    val markedResources = resourceTrackingRepository.getMarkedResources()
-    if (expand == null || expand == false) {
-      return markedResources.map { it.slim() }
+    return resourceTrackingRepository.getMarkedResources().let { markedResources ->
+      if (expand) markedResources else markedResources.map { it.slim() }
     }
-    return markedResources
+  }
+
+  @RequestMapping(value = ["/marked/{namespace}/{resourceId}"], method = [RequestMethod.GET])
+  fun markedResource(
+    @PathVariable namespace: String,
+    @PathVariable resourceId: String
+  ): MarkedResource {
+    return resourceTrackingRepository.find(resourceId, namespace)
+      ?: throw NotFoundException("Resource $namespace/$resourceId not found")
   }
 
   @RequestMapping(value = ["/canDelete"], method = [RequestMethod.GET])

--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
@@ -20,9 +20,7 @@ import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import com.netflix.spinnaker.swabbie.ResourceStateRepository
 import com.netflix.spinnaker.swabbie.ResourceTrackingRepository
 import com.netflix.spinnaker.swabbie.events.OptOutResourceEvent
-import com.netflix.spinnaker.swabbie.model.MarkedResource
-import com.netflix.spinnaker.swabbie.model.ResourceState
-import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import com.netflix.spinnaker.swabbie.model.*
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.web.bind.annotation.*
 
@@ -35,7 +33,15 @@ class ResourceController(
   private val workConfigurations: List<WorkConfiguration>
   ) {
   @RequestMapping(value = ["/marked"], method = [RequestMethod.GET])
-  fun markedResources(): List<MarkedResource> = resourceTrackingRepository.getMarkedResources()
+  fun markedResources(
+    @RequestParam(required = false) expand: Boolean?
+  ): List<MarkedResourceInterface> {
+    val markedResources = resourceTrackingRepository.getMarkedResources()
+    if (expand == null || expand == false) {
+      return markedResources.map { it.slim() }
+    }
+    return markedResources
+  }
 
   @RequestMapping(value = ["/canDelete"], method = [RequestMethod.GET])
   fun markedResourcesReadyForDeletion(): List<MarkedResource> = resourceTrackingRepository.getMarkedResourcesToDelete()


### PR DESCRIPTION
Upgrade kotlin version

Add a slim option for marked resource which gives you the identifying info and violations but not the whole resource object. This is the default. Get the full details by going to `https://localhost:8088/resources/marked?expand=true`

Also adding an endpoint to get a single marked resource `https://localhost:8088/resources/marked/{namespace}/{resourceId}`