### PR TITLE
feat(controller): get marked resources by namespace

### DIFF
--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
@@ -42,6 +42,18 @@ class ResourceController(
     }
   }
 
+  @RequestMapping(value = ["/marked/{namespace}"], method = [RequestMethod.GET])
+  fun markedResource(
+    @PathVariable namespace: String,
+    @RequestParam(required = false, defaultValue = "false") expand: Boolean
+  ): List<MarkedResourceInterface> {
+    return resourceTrackingRepository.getMarkedResources()
+      .filter { it.namespace == namespace }
+      .let { markedResources ->
+        if (expand) markedResources else markedResources.map { it.slim() }
+      }
+  }
+
   @RequestMapping(value = ["/marked/{namespace}/{resourceId}"], method = [RequestMethod.GET])
   fun markedResource(
     @PathVariable namespace: String,


### PR DESCRIPTION
Adding some useful apis to drill down into marked resources. this separates by namespace so you can look at all images in an account and region or whatever you'd like