### PR TITLE
fix(handler): Fixing bug on excluding a candidate

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -323,7 +323,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
           var shouldSkip = false
           val candidate = candidates.find { it.resourceId == r.resourceId }
           if ((candidate == null || candidate.getViolations().isEmpty()) ||
-            shouldExcludeResource(candidates.first(), workConfiguration, optedOutResourceStates, Action.DELETE)) {
+            shouldExcludeResource(candidate, workConfiguration, optedOutResourceStates, Action.DELETE)) {
             shouldSkip = true
             ensureResourceUnmarked(r, workConfiguration)
           }


### PR DESCRIPTION
- fixed a stupid but deadly bug on candidate exclusion
- should not be grabbing the same element over in the filter