### PR TITLE
feat(mark): api to see if resource would be marked

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandler.kt
@@ -152,11 +152,12 @@ class AmazonAutoScalingGroupHandler(
   }
 
   override fun getCandidate(
-    markedResource: MarkedResource,
+    resourceId: String,
+    resourceName: String,
     workConfiguration: WorkConfiguration
   ): AmazonAutoScalingGroup? {
     val params = Parameters(mapOf(
-      "autoScalingGroupName" to markedResource.resourceId,
+      "autoScalingGroupName" to resourceId,
       "account" to workConfiguration.account.accountId!!,
       "region" to workConfiguration.location)
     )

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -190,7 +190,7 @@ class AmazonImageHandler(
     )
 
     return imageProvider.getAll(params).also { images ->
-      log.info("Got {} images. Checking references", images?.size)
+      log.info("Got {} images.", images?.size)
     }
   }
 
@@ -219,7 +219,7 @@ class AmazonImageHandler(
       return
     }
 
-    log.info("checking references for {} resources. Parameters: {}", images.size, params)
+    log.debug("checking references for {} resources. Parameters: {}", images.size, params)
 
     images.forEach {
       if (it.name == null || it.description == null) {
@@ -362,9 +362,9 @@ class AmazonImageHandler(
     }
   }
 
-  override fun getCandidate(markedResource: MarkedResource, workConfiguration: WorkConfiguration): AmazonImage? {
+  override fun getCandidate(resourceId: String, resourceName: String, workConfiguration: WorkConfiguration): AmazonImage? {
     val params = Parameters(mapOf(
-      "imageId" to markedResource.resourceId,
+      "imageId" to resourceId,
       "account" to workConfiguration.account.accountId!!,
       "region" to workConfiguration.location)
     )

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -141,7 +141,7 @@ class AmazonImageHandler(
     while (getTask(taskId).status.isIncomplete()) {
       for (markedResource in markedResources) {
         try {
-          val candidate: AmazonImage? = getCandidate(markedResource, workConfiguration)
+          val candidate: AmazonImage? = getCandidate(markedResource.resourceId, markedResource.name.orEmpty(), workConfiguration)
           if (candidate == null) {
             log.debug("Deletion in progress for orca task $taskId. Successfully deleted {}...", markedResource)
             send(markedResource)

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
@@ -22,8 +22,6 @@ import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer
 import com.netflix.spinnaker.swabbie.*
 import com.netflix.spinnaker.swabbie.aws.autoscalinggroups.AmazonAutoScalingGroup
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
-import com.netflix.spinnaker.swabbie.model.AWS
-import com.netflix.spinnaker.swabbie.model.LOAD_BALANCER
 import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.Rule
 import com.netflix.spinnaker.swabbie.orca.OrcaService
@@ -101,12 +99,13 @@ class AmazonLoadBalancerHandler(
     }
   }
 
-  override fun getCandidate(markedResource: MarkedResource,
+  override fun getCandidate(resourceId: String,
+                            resourceName: String,
                             workConfiguration: WorkConfiguration
   ): AmazonElasticLoadBalancer? = loadBalancerProvider.getOne(
     Parameters(
       mapOf(
-        "loadBalancerName" to markedResource.name!!,
+        "loadBalancerName" to resourceName!!,
         "account" to workConfiguration.account.accountId!!,
         "region" to workConfiguration.location
       )

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
@@ -95,12 +95,13 @@ class AmazonSecurityGroupHandler(
     }
   }
 
-  override fun getCandidate(markedResource: MarkedResource,
+  override fun getCandidate(resourceId: String,
+                            resourceName: String,
                             workConfiguration: WorkConfiguration
   ): AmazonSecurityGroup? = securityGroupProvider.getOne(
     Parameters(
       mapOf(
-        "groupId" to markedResource.resourceId,
+        "groupId" to resourceId,
         "account" to workConfiguration.account.accountId!!,
         "region" to workConfiguration.location
       )

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandler.kt
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.swabbie
 
-import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.Resource
+import com.netflix.spinnaker.swabbie.model.ResourceEvauation
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 
 interface ResourceTypeHandler<T : Resource> {
@@ -37,7 +37,7 @@ interface ResourceTypeHandler<T : Resource> {
    * Fetches a single resource.
    * Decorate metadata that can be used in a [Rule]
    */
-  fun getCandidate(markedResource: MarkedResource, workConfiguration: WorkConfiguration): T?
+  fun getCandidate(resourceId: String, resourceName: String, workConfiguration: WorkConfiguration): T?
 
   /**
    * Marks a single marked resource matching the granularity of [WorkConfiguration].
@@ -60,4 +60,9 @@ interface ResourceTypeHandler<T : Resource> {
    * A rule should leverage metadata added by this function.
    */
   fun preProcessCandidates(candidates: List<T>, workConfiguration: WorkConfiguration): List<T>
+
+  /**
+   * Decides whether a single candidate will be marked, and returns information about that decision.
+   */
+  fun evaluateCandidate(resourceId: String, resourceName: String, workConfiguration: WorkConfiguration): ResourceEvauation
 }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
@@ -180,6 +180,14 @@ data class Status(
   val timestamp: Long
 )
 
+data class ResourceEvauation(
+  val namespace: String,
+  val resourceId: String,
+  val wouldMark: Boolean,
+  val wouldMarkReason: String,
+  val summaries: List<Summary>
+)
+
 fun MarkedResource.humanReadableDeletionTime(clock: Clock): LocalDate {
   this.projectedDeletionStamp.let {
     return Instant.ofEpochMilli(it)

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
@@ -591,10 +591,11 @@ object ResourceTypeHandlerTest {
 
     // simulates querying for a resource upstream
     override fun getCandidate(
-      markedResource: MarkedResource,
+      resourceId: String,
+      resourceName: String,
       workConfiguration: WorkConfiguration
     ): TestResource? {
-      return simulatedCandidates?.find { markedResource.resourceId == it.resourceId }
+      return simulatedCandidates?.find { resourceId == it.resourceId }
     }
 
     override fun preProcessCandidates(
@@ -611,6 +612,16 @@ object ResourceTypeHandlerTest {
 
     override fun getCandidates(workConfiguration: WorkConfiguration): List<TestResource>? {
       return simulatedCandidates
+    }
+
+    override fun evaluateCandidate(resourceId: String, resourceName: String, workConfiguration: WorkConfiguration): ResourceEvauation {
+      return ResourceEvauation(
+        namespace = workConfiguration.namespace,
+        resourceId = resourceId,
+        wouldMark = false,
+        wouldMarkReason = "This is a test",
+        summaries = listOf()
+      )
     }
   }
 }

--- a/swabbie-web/src/test/kotlin/com/netflix/spinnaker/swabbie/web/ResourceControllerTest.kt
+++ b/swabbie-web/src/test/kotlin/com/netflix/spinnaker/swabbie/web/ResourceControllerTest.kt
@@ -1,0 +1,118 @@
+package com.netflix.spinnaker.swabbie.web
+
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.should.shouldMatch
+import com.netflix.spinnaker.config.ExclusionType
+import com.netflix.spinnaker.swabbie.AccountProvider
+import com.netflix.spinnaker.swabbie.ResourceStateRepository
+import com.netflix.spinnaker.swabbie.ResourceTrackingRepository
+import com.netflix.spinnaker.swabbie.ResourceTypeHandler
+import com.netflix.spinnaker.swabbie.aws.images.AmazonImage
+import com.netflix.spinnaker.swabbie.aws.images.AmazonImageHandler
+import com.netflix.spinnaker.swabbie.controllers.Namespace
+import com.netflix.spinnaker.swabbie.controllers.ResourceController
+import com.netflix.spinnaker.swabbie.model.*
+import com.nhaarman.mockito_kotlin.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDateTime
+
+object ResourceControllerTest {
+  private val resourceStateRepository = mock<ResourceStateRepository>()
+  private val resourceTrackingRepository = mock<ResourceTrackingRepository>()
+  private val applicationEventPublisher = mock<ApplicationEventPublisher>()
+  private val workConfigurations = mock<List<WorkConfiguration>>()
+  private val accountProvider = mock<AccountProvider>()
+  private val resourceTypeHandlers = mock<List<ResourceTypeHandler<*>>>()
+
+  private val subject = ResourceController(
+    resourceStateRepository,
+    resourceTrackingRepository,
+    applicationEventPublisher,
+    workConfigurations,
+    accountProvider,
+    resourceTypeHandlers
+  )
+
+  @BeforeEach
+  fun setup() {
+
+    whenever(accountProvider.getAccounts()) doReturn
+      setOf(
+        SpinnakerAccount(
+          name = "test",
+          accountId = "1234",
+          type = "aws",
+          edda = "http://edda",
+          regions = listOf(Region(name = "us-east-1")),
+          eddaEnabled = false
+        ),
+        SpinnakerAccount(
+          name = "prod",
+          accountId = "4321",
+          type = "aws",
+          edda = "http://edda",
+          regions = listOf(Region(name = "us-east-1")),
+          eddaEnabled = false
+        )
+      )
+
+    val image = AmazonImage(
+      imageId = "ami-123",
+      resourceId = "ami-123",
+      description = "ancestor_id=ami-122",
+      ownerId = null,
+      state = "available",
+      resourceType = IMAGE,
+      cloudProvider = AWS,
+      name = "123-xenial-hvm-sriov-ebs",
+      creationDate = LocalDateTime.now().minusDays(3).toString()
+    )
+
+    val oneDayAgo = System.currentTimeMillis() - 1 * 24 * 60 * 60 * 1000L
+    val tenDaysFromNow = System.currentTimeMillis() + 10 * 24 * 60 * 60 * 1000L
+
+    whenever(resourceTrackingRepository.getMarkedResources()) doReturn
+      listOf(
+        MarkedResource(
+          resource = image,
+          summaries = listOf(Summary("Image is unused", "testRule 1")),
+          namespace = "aws:test:us-east-1:image",
+          resourceOwner = "test@netflix.com",
+          projectedDeletionStamp = tenDaysFromNow,
+          notificationInfo = NotificationInfo(
+            recipient = "test@netflix.com",
+            notificationType = "Email",
+            notificationStamp = oneDayAgo
+          )
+        )
+      )
+  }
+
+  @AfterEach
+  fun cleanup() {
+    validateMockitoUsage()
+    reset(accountProvider, applicationEventPublisher)
+  }
+
+  @Test
+  fun `returns marked resources`() {
+    subject.markedResources(false).size shouldMatch equalTo(1)
+  }
+
+  @Test
+  fun `generates correct work configuration`() {
+    val namespace = Namespace("aws", "test", "us-east-1", "image")
+    val resourceId = "ami-123"
+
+    val workConfiguration = subject.getWorkConfiguration(namespace)
+
+    workConfiguration.account.accountId shouldMatch equalTo("1234")
+    workConfiguration.namespace shouldMatch equalTo(namespace.toString())
+    workConfiguration.exclusions[0].type shouldMatch equalTo(ExclusionType.Allowlist.toString())
+    workConfiguration.exclusions[0].attributes.first().key shouldMatch equalTo("name")
+    workConfiguration.exclusions[0].attributes.first().value shouldMatch equalTo(listOf(resourceId))
+  }
+}

--- a/swabbie-web/src/test/kotlin/com/netflix/spinnaker/swabbie/web/ResourceControllerTest.kt
+++ b/swabbie-web/src/test/kotlin/com/netflix/spinnaker/swabbie/web/ResourceControllerTest.kt
@@ -105,14 +105,11 @@ object ResourceControllerTest {
   @Test
   fun `generates correct work configuration`() {
     val namespace = Namespace("aws", "test", "us-east-1", "image")
-    val resourceId = "ami-123"
 
     val workConfiguration = subject.getWorkConfiguration(namespace)
 
     workConfiguration.account.accountId shouldMatch equalTo("1234")
     workConfiguration.namespace shouldMatch equalTo(namespace.toString())
-    workConfiguration.exclusions[0].type shouldMatch equalTo(ExclusionType.Allowlist.toString())
-    workConfiguration.exclusions[0].attributes.first().key shouldMatch equalTo("name")
-    workConfiguration.exclusions[0].attributes.first().value shouldMatch equalTo(listOf(resourceId))
+    workConfiguration.exclusions shouldMatch equalTo(listOf())
   }
 }


### PR DESCRIPTION
Adding `evaluateCandidate` method, exposed via api, to grab a single resource and then run it through the marking logic.

Hopefully this will be useful when checking rules so that we can on-demand run the `preProcessing` logic and ensure that a resource is marked or not marked.