### PR TITLE
feat(rules): track when we saw an image in use last

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
   group = "com.netflix.spinnaker.swabbie"
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '1.0.18'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '1.2.5'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/instances/AmazonInstance.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/instances/AmazonInstance.kt
@@ -28,6 +28,7 @@ import java.time.ZoneId
 data class AmazonInstance(
   private val instanceId: String,
   val imageId: String,
+  val tags: List<Map<String, String>>,
   private val launchTime: Long,
   override val resourceId: String = instanceId,
   override val resourceType: String = INSTANCE,
@@ -35,4 +36,10 @@ data class AmazonInstance(
   override val name: String = instanceId,
   private val creationDate: String? =
     LocalDateTime.ofInstant(Instant.ofEpochMilli(launchTime), ZoneId.systemDefault()).toString()
-) : AmazonResource(creationDate)
+) : AmazonResource(creationDate) {
+  fun getAutoscalingGroup(): String? {
+    return tags
+      .find { it.containsKey("aws:autoscaling:groupName") }
+      ?.get("aws:autoscaling:groupName")
+  }
+}

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchconfigurations/LaunchConfiguration.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchconfigurations/LaunchConfiguration.kt
@@ -35,4 +35,7 @@ data class AmazonLaunchConfiguration(
   override val name: String = launchConfigurationName,
   private val creationDate: String? =
     LocalDateTime.ofInstant(Instant.ofEpochMilli(createdTime), ZoneId.systemDefault()).toString()
-) : AmazonResource(creationDate)
+) : AmazonResource(creationDate) {
+  fun getAutoscalingGroupName() =
+    launchConfigurationName.substringBeforeLast("-")
+}

--- a/swabbie-aws/swabbie-aws.gradle
+++ b/swabbie-aws/swabbie-aws.gradle
@@ -18,6 +18,8 @@ dependencies {
   compile project(":swabbie-core")
   compile project(":swabbie-orca")
   compile project(":swabbie-retrofit")
+  compile spinnaker.dependency("aws")
+
 
   testCompile project(":swabbie-test")
 }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
@@ -26,6 +26,7 @@ import java.time.ZoneId
 @ConfigurationProperties("swabbie")
 open class SwabbieProperties {
   var dryRun: Boolean = true
+  var outOfUseThresholdDays: Int = 30
   var providers: List<CloudProviderConfiguration> = mutableListOf()
   var schedule: Schedule = Schedule()
   var testing: Testing = Testing()

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/ResourceUseTrackingRepository.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/ResourceUseTrackingRepository.kt
@@ -1,0 +1,46 @@
+/*
+ *
+ *  * Copyright 2018 Netflix, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License")
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.repository
+
+interface ResourceUseTrackingRepository {
+  /**
+   * record that resource is used by another resource at this exact time
+   */
+  fun recordUse(resourceIdentifier: String, usedByResourceIdentifier: String)
+
+  /**
+   * gets resources that haven't been seen in use for X days
+   */
+  fun getUnused(): List<LastSeenInfo>
+
+  fun isUnused(resourceIdentifier: String): Boolean
+
+  /**
+   * Returns true if data is present for the whole outOfUseThreshold period.
+   * Returns false if data is only present for part of the period,
+   *  i.e. if the outOfUseThreshold is 10 days but we only have data for 5.
+   */
+  fun hasCompleteData(): Boolean
+}
+
+data class LastSeenInfo(
+  val resourceIdentifier: String,
+  val usedByResourceIdentifier: String,
+  val timeSeen: Long
+)

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceTrackingRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceTrackingRepository.kt
@@ -30,7 +30,7 @@ import java.time.Instant
 
 @Component
 class RedisResourceTrackingRepository(
-  @Qualifier("redisClientSelector") redisClientSelector: RedisClientSelector,
+  redisClientSelector: RedisClientSelector,
   private val objectMapper: ObjectMapper,
   private val clock: Clock
 ) : ResourceTrackingRepository {

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceUseTrackingRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceUseTrackingRepository.kt
@@ -1,0 +1,104 @@
+/*
+ *
+ *  * Copyright 2018 Netflix, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License")
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.redis
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.config.SwabbieProperties
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.RedisClientSelector
+import com.netflix.spinnaker.swabbie.repository.LastSeenInfo
+import com.netflix.spinnaker.swabbie.repository.ResourceUseTrackingRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+@Component
+class RedisResourceUseTrackingRepository(
+  redisClientSelector: RedisClientSelector,
+  private val objectMapper: ObjectMapper,
+  private val clock: Clock,
+  swabbieProperties: SwabbieProperties
+) : ResourceUseTrackingRepository {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+  private val LAST_SEEN = "{swabbie:resourceUseTracking}:lastseen"
+  private val READY_FOR_CLEANING = "{swabbie:resourceUseTracking}:readyforcleaning"
+  private val INIT_TIME = "swabbie:inittime"
+  private val outOfUseThresholdDays = swabbieProperties.outOfUseThresholdDays
+
+  private val redisClientDelegate: RedisClientDelegate = redisClientSelector.primary("default")
+
+  init {
+    log.info("Using ${javaClass.simpleName}")
+
+    redisClientDelegate.withCommandsClient { client ->
+      client.setnx(INIT_TIME, clock.instant().toEpochMilli().toString())
+    }
+  }
+
+  override fun hasCompleteData(): Boolean {
+    return redisClientDelegate.withCommandsClient<String> { client ->
+      client.get(INIT_TIME)
+    }.toLong() < clock.instant().minus(Duration.ofDays(outOfUseThresholdDays.toLong())).toEpochMilli()
+  }
+
+  override fun recordUse(resourceIdentifier: String, usedByResourceIdentifier: String) {
+    redisClientDelegate.withCommandsClient { client ->
+      client.hset(
+        LAST_SEEN,
+        resourceIdentifier,
+        objectMapper.writeValueAsString(
+          LastSeenInfo(resourceIdentifier, usedByResourceIdentifier, clock.instant().toEpochMilli()))
+      )
+      // add to sorted set by score
+      // score = day when resource will be ready to delete
+      // if resource is seen in next X days, resource will be updated
+      client.zadd(READY_FOR_CLEANING, plusXdays(outOfUseThresholdDays).toDouble(), resourceIdentifier)
+    }
+  }
+
+  override fun getUnused(): List<LastSeenInfo> {
+    val keys = redisClientDelegate.withCommandsClient<Set<String>> { client ->
+      client.zrangeByScore(READY_FOR_CLEANING, 0.0, clock.instant().toEpochMilli().toDouble())
+    }
+    return hydrateLastSeen(keys)
+  }
+
+  private fun hydrateLastSeen(keys: Set<String>): List<LastSeenInfo> {
+    if (keys.isEmpty()) return emptyList()
+    return redisClientDelegate.withCommandsClient<Set<String>> { client ->
+      client.hmget(LAST_SEEN, *keys.toTypedArray()).toSet()
+    }.map { json ->
+      objectMapper.readValue<LastSeenInfo>(json)
+    }
+  }
+
+  override fun isUnused(resourceIdentifier: String): Boolean {
+    return redisClientDelegate.withCommandsClient<Double> { client ->
+      client.zscore(READY_FOR_CLEANING, resourceIdentifier)
+    }.toLong() < clock.instant().toEpochMilli()
+  }
+
+  fun plusXdays(days: Int): Long {
+    return clock.instant().plus(days.toLong(), ChronoUnit.DAYS).toEpochMilli()
+  }
+}

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisTaskTrackingRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisTaskTrackingRepository.kt
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
 import com.netflix.spinnaker.swabbie.repository.TaskState
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
-import net.logstash.logback.argument.StructuredArguments.kv
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -34,7 +33,7 @@ import java.util.concurrent.TimeUnit
 
 @Component
 class RedisTaskTrackingRepository(
-  @Qualifier("redisClientSelector") redisClientSelector: RedisClientSelector,
+  redisClientSelector: RedisClientSelector,
   private val objectMapper: ObjectMapper,
   private val clock: Clock
 ) : TaskTrackingRepository {
@@ -141,6 +140,8 @@ class RedisTaskTrackingRepository(
   //todo eb: this actually cleans up running tasks as well
   override fun cleanUpFinishedTasks(daysToLeave: Int) {
     val allBefore: Set<String> = getAllBefore(daysToLeave)
+    if (allBefore.isEmpty()) return
+
     log.debug("Cleaning ${allBefore.size} tasks")
     redisClientDelegate.withCommandsClient { client ->
       client.hdel(TASK_STATUS_KEY, *allBefore.toTypedArray())

--- a/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceUseTrackingRepositoryTest.kt
+++ b/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceUseTrackingRepositoryTest.kt
@@ -1,0 +1,92 @@
+/*
+ *
+ *  * Copyright 2018 Netflix, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License")
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.redis
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.netflix.spinnaker.config.SwabbieProperties
+import com.netflix.spinnaker.config.resourceDeserializerModule
+import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.RedisClientSelector
+import com.netflix.spinnaker.swabbie.test.TestResource
+import main.java.com.netflix.spinnaker.kork.test.time.MutableClock
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.util.Assert
+import redis.clients.jedis.JedisPool
+import java.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+object RedisResourceUseTrackingRepositoryTest {
+
+  private val embeddedRedis = EmbeddedRedis.embed()
+  private val jedisPool = embeddedRedis.pool as JedisPool
+  private val objectMapper = ObjectMapper().apply {
+    registerSubtypes(TestResource::class.java)
+    registerModule(KotlinModule())
+    registerModule(resourceDeserializerModule())
+    disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+  }
+
+  private val clock = MutableClock()
+
+  private val resourceUseTrackingRepository = RedisResourceUseTrackingRepository(
+    RedisClientSelector(listOf(JedisClientDelegate("primaryDefault", jedisPool))),
+    objectMapper,
+    clock,
+    SwabbieProperties().apply { outOfUseThresholdDays = 3 }
+  )
+
+  @BeforeEach
+  fun setup() {
+    jedisPool.resource.use {
+      it.flushDB()
+    }
+  }
+
+  @AfterAll
+  fun cleanup() {
+    embeddedRedis.destroy()
+  }
+
+  @Test
+  fun `adds a resource correctly`() {
+    resourceUseTrackingRepository.recordUse("ami-111", "servergroup-v001")
+    Assert.isTrue(!resourceUseTrackingRepository.isUnused("ami-111"), "ami was just seen, it shouldn't be unused")
+  }
+
+  @Test
+  fun `correctly returns unused resource after 5 days`() {
+    resourceUseTrackingRepository.recordUse("ami-111", "servergroup-v001")
+    clock.incrementBy(Duration.ofDays(2))
+    resourceUseTrackingRepository.recordUse("ami-222", "anothersg-v004")
+    clock.incrementBy(Duration.ofDays(2))
+
+    val unused = resourceUseTrackingRepository.getUnused()
+    Assert.notEmpty(unused, "ami should be unused after 5 days")
+    Assert.isTrue(
+      unused.first().usedByResourceIdentifier == "servergroup-v001",
+      "should be the correct server group"
+    )
+  }
+}

--- a/swabbie-redis/swabbie-redis.gradle
+++ b/swabbie-redis/swabbie-redis.gradle
@@ -20,6 +20,7 @@ dependencies {
   compile spinnaker.dependency('jedis')
   compile spinnaker.dependency('korkJedis')
   compile spinnaker.dependency('korkDynomite')
+  compile spinnaker.dependency('korkTest')
 
   testCompile spinnaker.dependency('korkJedisTest')
   testCompile project(":swabbie-test")


### PR DESCRIPTION
Add a `ResourceUseTrackingRepository` to record when we see an image in use, and what server group that is a part of. 

Updated `AmazonImageHandler` to record what resource (server group) we saw an image used by.

Add ` outOfUseThresholdDays: 30` config option to control how long a resource can be unused for before we consider it able to be deleted (and mark it): 
```yaml
swabbie:
  outOfUseThresholdDays: 30
```

Update the `OrphanedImageRule` to respect the allowed out of use period.