### PR TITLE
fix(image): faster sibling check using maps

### DIFF
--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
@@ -65,7 +65,7 @@ object AmazonImageHandlerTest {
   private val taggingService = mock<TaggingService>()
   private val taskTrackingRepository = mock<TaskTrackingRepository>()
   private val resourceUseTrackingRepository = mock<ResourceUseTrackingRepository>()
-  private val swabbieProperties = mock<SwabbieProperties>()
+  private val swabbieProperties = SwabbieProperties()
 
   private val subject = AmazonImageHandler(
     clock = clock,

--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
@@ -48,6 +48,11 @@ class ResourceController(
     }
   }
 
+  @RequestMapping(value = ["/numMarked"], method = [RequestMethod.GET])
+  fun numberMarkedResources(): Int {
+    return resourceTrackingRepository.getMarkedResources().count()
+  }
+
   @RequestMapping(value = ["/marked/{namespace}"], method = [RequestMethod.GET])
   fun markedResource(
     @PathVariable namespace: String,


### PR DESCRIPTION
Removing O(n^2) image sibling checking by pre-processing image using hash maps, then checking for keys in those.

Adding a 'numMarked' endpoint to easily see how many resources have been marked.

Bypassing the "last seen" check when outOfUseThreshold is set to 0.