### PR TITLE
feat(mark): removing mark of deleted resources, comments

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/exclusions/AllowListExclusionPolicy.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/exclusions/AllowListExclusionPolicy.kt
@@ -35,6 +35,11 @@ class AllowListExclusionPolicy(
   )
 
   override fun getType(): ExclusionType = ExclusionType.Allowlist
+
+  /**
+   * Takes a resource that can be excluded (an excludable), and a list of the configured exclusions, and
+   * determines if the resource can be excluded based on those rules.
+   */
   override fun apply(excludable: Excludable, exclusions: List<Exclusion>): String? {
     keysAndValues(exclusions, ExclusionType.Allowlist).let { kv ->
       if (kv.isEmpty()) {
@@ -54,11 +59,13 @@ class AllowListExclusionPolicy(
           }
         } else {
           findProperty(excludable, key, kv[key]!!)?.let {
+            // since a matching value is returned for the key, we know it is in the allowlist
             return null
           }
         }
       }
 
+      // if none of the keys have a qualifying value, the resource is not in the allowlist
       return notAllowlistedMessage(getIdentifierForType(excludable), kv.values.flatten().toSet())
     }
   }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/exclusions/ExclusionPolicy.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/exclusions/ExclusionPolicy.kt
@@ -105,6 +105,11 @@ interface ExclusionPolicy {
     return instance.javaClass.kotlin.memberProperties.first { it.name == propertyName }.get(instance) as R
   }
 
+  /**
+   * Takes a list of config-defined exlusions.
+   * For each exclusion that matches the type we're considering,
+   * transform all information into a key,values that make up this policy
+   */
   fun keysAndValues(exclusions: List<Exclusion>, type: ExclusionType): Map<String, List<String>> {
     val map = mutableMapOf<String, List<String>>()
     exclusions.filter {
@@ -146,6 +151,10 @@ data class ExclusionResult(
 )
 
 interface Excludable : Identifiable {
+  /**
+   * @param exclusionPolicies: all possible policies defined in code
+   * @param exclusions: actual configured policies based on swabbie.yml
+   */
   fun shouldBeExcluded(exclusionPolicies: List<ExclusionPolicy>, exclusions: List<Exclusion>): ExclusionResult {
     exclusionPolicies.mapNotNull { it.apply(this, exclusions) }.let { reasons ->
       return ExclusionResult(!reasons.isEmpty(), reasons.toSet())


### PR DESCRIPTION
- adding javadocs
- adding (and logging) a reason for why something is unmarked
- removing resources that no longer exist from the marked database before we run the mark cycle. This makes it easier to view swabbie's list of marked resources, since after a resource is deleted not using swabbie, swabbie will update the state it has.
- add an allow list test for an example