### PR TITLE
feat(lastSeen): adding last seen info to markedResource

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandler.kt
@@ -35,10 +35,7 @@ import com.netflix.spinnaker.swabbie.notifications.Notifier
 import com.netflix.spinnaker.swabbie.orca.OrcaJob
 import com.netflix.spinnaker.swabbie.orca.OrcaService
 import com.netflix.spinnaker.swabbie.orca.OrchestrationRequest
-import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
-import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
-import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
-import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
+import com.netflix.spinnaker.swabbie.repository.*
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.Clock
@@ -60,7 +57,8 @@ class AmazonAutoScalingGroupHandler(
   private val rules: List<Rule<AmazonAutoScalingGroup>>,
   private val serverGroupProvider: ResourceProvider<AmazonAutoScalingGroup>,
   private val orcaService: OrcaService,
-  private val taskTrackingRepository: TaskTrackingRepository
+  private val taskTrackingRepository: TaskTrackingRepository,
+  private val resourceUseTrackingRepository: ResourceUseTrackingRepository
 ) : AbstractResourceTypeHandler<AmazonAutoScalingGroup>(
   registry,
   clock,
@@ -72,7 +70,8 @@ class AmazonAutoScalingGroupHandler(
   notifiers,
   applicationEventPublisher,
   lockingService,
-  retrySupport
+  retrySupport,
+  resourceUseTrackingRepository
 ) {
 
   override fun softDeleteResources(markedResources: List<MarkedResource>, workConfiguration: WorkConfiguration) {

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
@@ -30,10 +30,7 @@ import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.notifications.Notifier
 import com.netflix.spinnaker.swabbie.orca.OrcaJob
 import com.netflix.spinnaker.swabbie.orca.OrchestrationRequest
-import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
-import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
-import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
-import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
+import com.netflix.spinnaker.swabbie.repository.*
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.Clock
@@ -55,7 +52,8 @@ class AmazonLoadBalancerHandler(
   private val loadBalancerProvider: ResourceProvider<AmazonElasticLoadBalancer>,
   private val serverGroupProvider: ResourceProvider<AmazonAutoScalingGroup>,
   private val orcaService: OrcaService,
-  private val taskTrackingRepository: TaskTrackingRepository
+  private val taskTrackingRepository: TaskTrackingRepository,
+  private val resourceUseTrackingRepository: ResourceUseTrackingRepository
 ) : AbstractResourceTypeHandler<AmazonElasticLoadBalancer>(
   registry,
   clock,
@@ -67,7 +65,8 @@ class AmazonLoadBalancerHandler(
   notifiers,
   applicationEventPublisher,
   lockingService,
-  retrySupport
+  retrySupport,
+  resourceUseTrackingRepository
 ) {
   override fun deleteResources(
     markedResources: List<MarkedResource>,

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
@@ -27,10 +27,7 @@ import com.netflix.spinnaker.swabbie.notifications.Notifier
 import com.netflix.spinnaker.swabbie.orca.OrcaJob
 import com.netflix.spinnaker.swabbie.orca.OrcaService
 import com.netflix.spinnaker.swabbie.orca.OrchestrationRequest
-import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
-import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
-import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
-import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
+import com.netflix.spinnaker.swabbie.repository.*
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.Clock
@@ -52,7 +49,8 @@ class AmazonSecurityGroupHandler(
   private val rules: List<Rule<AmazonSecurityGroup>>,
   private val securityGroupProvider: ResourceProvider<AmazonSecurityGroup>,
   private val orcaService: OrcaService,
-  private val taskTrackingRepository: TaskTrackingRepository
+  private val taskTrackingRepository: TaskTrackingRepository,
+  private val resourceUseTrackingRepository: ResourceUseTrackingRepository
 ) : AbstractResourceTypeHandler<AmazonSecurityGroup>(
   registry,
   clock,
@@ -64,7 +62,8 @@ class AmazonSecurityGroupHandler(
   notifiers,
   applicationEventPublisher,
   lockingService,
-  retrySupport
+  retrySupport,
+  resourceUseTrackingRepository
 ) {
   override fun deleteResources(
     markedResources: List<MarkedResource>,

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandlerTest.kt
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.swabbie.orca.TaskDetailResponse
 import com.netflix.spinnaker.swabbie.orca.TaskResponse
 import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
 import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
+import com.netflix.spinnaker.swabbie.repository.ResourceUseTrackingRepository
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.nhaarman.mockito_kotlin.*
 import org.junit.jupiter.api.AfterEach
@@ -56,6 +57,7 @@ object AmazonAutoScalingGroupHandlerTest {
   private val applicationEventPublisher = mock<ApplicationEventPublisher>()
   private val lockingService = Optional.empty<LockingService>()
   private val orcaService = mock<OrcaService>()
+  private val resourceUseTrackingRepository = mock<ResourceUseTrackingRepository>()
 
   private val subject = AmazonAutoScalingGroupHandler(
     clock = clock,
@@ -75,7 +77,8 @@ object AmazonAutoScalingGroupHandlerTest {
     lockingService = lockingService,
     retrySupport = RetrySupport(),
     serverGroupProvider = serverGroupProvider,
-    orcaService = orcaService
+    orcaService = orcaService,
+    resourceUseTrackingRepository = resourceUseTrackingRepository
   )
 
   @BeforeEach

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
@@ -471,6 +471,7 @@ object AmazonImageHandlerTest {
   fun `should not soft delete if the images have been seen recently`() {
     whenever(resourceUseTrackingRepository.getUnused()) doReturn
       emptyList<LastSeenInfo>()
+    whenever(resourceUseTrackingRepository.getUsed()) doReturn setOf("ami-123")
 
     val fifteenDaysAgo = clock.instant().minusSeconds(15 * 24 * 60 * 60).toEpochMilli()
     val thirteenDaysAgo = clock.instant().minusSeconds(13 * 24 * 60 * 60).toEpochMilli()

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/OnDemandMarkData.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/OnDemandMarkData.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.swabbie.model
 
 import com.netflix.spinnaker.swabbie.notifications.Notifier
+import com.netflix.spinnaker.swabbie.repository.LastSeenInfo
 
 data class OnDemandMarkData(
   var projectedSoftDeletionStamp: Long,
@@ -11,5 +12,6 @@ data class OnDemandMarkData(
     recipient = resourceOwner,
     notificationType = Notifier.NotificationType.EMAIL.name,
     notificationCount = 1
-  )
+  ),
+  var lastSeenInfo: LastSeenInfo? = null
 )

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.netflix.spinnaker.swabbie.exclusions.Excludable
+import com.netflix.spinnaker.swabbie.repository.LastSeenInfo
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -114,6 +115,7 @@ interface MarkedResourceInterface : Identifiable {
   var markTs: Long?
   var updateTs: Long?
   val resourceOwner: String
+  var lastSeenInfo: LastSeenInfo?
 }
 
 /**
@@ -129,22 +131,24 @@ data class MarkedResource(
   override var notificationInfo: NotificationInfo? = null,
   override var markTs: Long? = null,
   override var updateTs: Long? = null,
-  override var resourceOwner: String = ""
+  override var resourceOwner: String = "",
+  override var lastSeenInfo: LastSeenInfo? = null
 ) : MarkedResourceInterface, Identifiable by resource {
   fun slim(): SlimMarkedResource {
     return SlimMarkedResource(
-      summaries,
-      namespace,
-      projectedSoftDeletionStamp,
-      projectedDeletionStamp,
-      notificationInfo,
-      markTs,
-      updateTs,
-      resourceOwner,
-      resource.resourceId,
-      resource.resourceType,
-      resource.cloudProvider,
-      resource.name
+      summaries = summaries,
+      namespace = namespace,
+      projectedSoftDeletionStamp = projectedSoftDeletionStamp,
+      projectedDeletionStamp = projectedDeletionStamp,
+      notificationInfo = notificationInfo,
+      markTs = markTs,
+      updateTs = updateTs,
+      resourceOwner = resourceOwner,
+      resourceId = resource.resourceId,
+      resourceType = resource.resourceType,
+      cloudProvider = resource.cloudProvider,
+      name = resource.name,
+      lastSeenInfo = lastSeenInfo
     )
   }
 
@@ -165,7 +169,8 @@ data class SlimMarkedResource (
   override val resourceId: String,
   override val resourceType: String,
   override val cloudProvider: String,
-  override val name: String?
+  override val name: String?,
+  override var lastSeenInfo: LastSeenInfo? = null
 ) : MarkedResourceInterface
 
 data class NotificationInfo(

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/ResourceUseTrackingRepository.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/ResourceUseTrackingRepository.kt
@@ -29,7 +29,14 @@ interface ResourceUseTrackingRepository {
    */
   fun getUnused(): List<LastSeenInfo>
 
+  /**
+   * gets all resources that we have seen in use within the threshold
+   */
+  fun getUsed(): Set<String>
+
   fun isUnused(resourceIdentifier: String): Boolean
+
+  fun getLastSeenInfo(resourceIdentifier: String): LastSeenInfo?
 
   /**
    * Returns true if data is present for the whole outOfUseThreshold period.
@@ -40,7 +47,7 @@ interface ResourceUseTrackingRepository {
 }
 
 data class LastSeenInfo(
-  val resourceIdentifier: String,
-  val usedByResourceIdentifier: String,
+  val resourceId: String,
+  val usedByResourceId: String,
   val timeSeen: Long
 )

--- a/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceUseTrackingRepositoryTest.kt
+++ b/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceUseTrackingRepositoryTest.kt
@@ -85,8 +85,29 @@ object RedisResourceUseTrackingRepositoryTest {
     val unused = resourceUseTrackingRepository.getUnused()
     Assert.notEmpty(unused, "ami should be unused after 5 days")
     Assert.isTrue(
-      unused.first().usedByResourceIdentifier == "servergroup-v001",
+      unused.first().usedByResourceId == "servergroup-v001",
       "should be the correct server group"
+    )
+  }
+
+  @Test
+  fun `returns null when no last seen info`() {
+    val info = resourceUseTrackingRepository.getLastSeenInfo("bla")
+    Assert.isNull(info, "resource is not tracked and shouldn't return info")
+  }
+
+  @Test
+  fun `returns list of in use resources`() {
+    resourceUseTrackingRepository.recordUse("ami-111", "servergroup-v001")
+    clock.incrementBy(Duration.ofDays(2))
+    resourceUseTrackingRepository.recordUse("ami-222", "anothersg-v004")
+    clock.incrementBy(Duration.ofDays(2))
+
+    val used = resourceUseTrackingRepository.getUsed()
+    Assert.notEmpty(used, "one resource should be in use")
+    Assert.isTrue(
+      used.first().equals("ami-222"),
+      "Resource has not yet met the out of use threshold number of days not seen"
     )
   }
 }


### PR DESCRIPTION
Making sure that if we've never seen a resource in use we don't mark it as SEEN_IN_USE. That way, when Swabbie starts up, it can both track usage and delete resources that we've never seen in use (like the old amis)

Storing the last seen info with marked resources, so that we can send the information in email notifications to make the more useful.

Sending the resources to echo as their `.slim()` version. We actually don't even need that much data, but I'll pair it down later. We're only rendering the good bits in the email.