### PR TITLE
Better in use checking for images

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
   group = "com.netflix.spinnaker.swabbie"
 
   ext {
-    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '1.2.5'
+    spinnakerDependenciesVersion = project.hasProperty('spinnakerDependenciesVersion') ? project.property('spinnakerDependenciesVersion') : '1.4.0'
   }
 
   def checkLocalVersions = [spinnakerDependenciesVersion: spinnakerDependenciesVersion]

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/instances/AmazonInstance.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/instances/AmazonInstance.kt
@@ -26,7 +26,7 @@ import java.time.ZoneId
 
 @JsonTypeName("amazonInstance")
 data class AmazonInstance(
-  private val instanceId: String,
+  val instanceId: String,
   val imageId: String,
   val tags: List<Map<String, String>>,
   private val launchTime: Long,

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
@@ -67,7 +67,10 @@ object AmazonImageHandlerTest {
   private val taggingService = mock<TaggingService>()
   private val taskTrackingRepository = mock<TaskTrackingRepository>()
   private val resourceUseTrackingRepository = mock<ResourceUseTrackingRepository>()
-  private val swabbieProperties = SwabbieProperties()
+  private val swabbieProperties = SwabbieProperties().apply {
+    minImagesUsedByInst = 0
+    minImagesUsedByLC = 0
+  }
   private val launchConfigurationCache = mock<InMemorySingletonCache<AmazonLaunchConfigurationCache>>()
   private val imagesUsedByinstancesCache = mock<InMemorySingletonCache<AmazonImagesUsedByInstancesCache>>()
 

--- a/swabbie-clouddriver/src/main/kotlin/com/netflix/spinnaker/swabbie/clouddriver/ClouddriverAccountProvider.kt
+++ b/swabbie-clouddriver/src/main/kotlin/com/netflix/spinnaker/swabbie/clouddriver/ClouddriverAccountProvider.kt
@@ -20,7 +20,6 @@ import com.netflix.spinnaker.swabbie.AccountProvider
 import com.netflix.spinnaker.swabbie.InMemoryCache
 import com.netflix.spinnaker.swabbie.model.Account
 import com.netflix.spinnaker.swabbie.model.SpinnakerAccount
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.stereotype.Component
 
 @Component

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
@@ -23,6 +23,12 @@ import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.ZoneId
 
+/**
+ * @param minImagesUsedByLC minimum number of images used by launch configurations that should be
+ *  in the cache. If not present agents will error to prevent mass marking in the case of edda problems.
+ * @param minImagesUsedByInst minimum number of images used by instances that should be
+ *  in the cache. If not present agents will error to prevent mass marking in the case of edda problems.
+ */
 @ConfigurationProperties("swabbie")
 open class SwabbieProperties {
   var dryRun: Boolean = true
@@ -30,6 +36,8 @@ open class SwabbieProperties {
   var providers: List<CloudProviderConfiguration> = mutableListOf()
   var schedule: Schedule = Schedule()
   var testing: Testing = Testing()
+  var minImagesUsedByLC = 500
+  var minImagesUsedByInst = 500
 }
 
 class Testing {

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CachedViewProvider.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CachedViewProvider.kt
@@ -1,10 +1,5 @@
 package com.netflix.spinnaker.swabbie
 
 interface CachedViewProvider<out T> {
-  /**
-   * Gets all resources with [Parameters]
-   */
-  fun getAll(params: Parameters): Collection<Any>
-
-  fun getLastUpdated(): Long
+  fun load(): T
 }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/exception/CacheSizeException.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/exception/CacheSizeException.kt
@@ -1,0 +1,24 @@
+/*
+ *
+ *  * Copyright 2018 Netflix, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License")
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.exception
+
+class CacheSizeException: RuntimeException {
+  constructor(message: String) : super(message)
+  constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/exception/StaleCacheException.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/exception/StaleCacheException.kt
@@ -1,0 +1,24 @@
+/*
+ *
+ *  * Copyright 2018 Netflix, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License")
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.exception
+
+class StaleCacheException: RuntimeException {
+  constructor(message: String) : super(message)
+  constructor(message: String, cause: Throwable) : super(message, cause)
+}


### PR DESCRIPTION
Creates singleton cache, useful for having an object that you want to refresh.
Use this singleton cache in the edda caches (and refactor those to not be `@Lazy`).
Update the `checkReferences(..)` logic in `AmazonImageHandler` to check if an image is used in any launch config in any account, then check if the image is used by any images in any account. 
Rip out the siblings check, as it is no longer needed because we are checking the use in all accounts.
