### PR TITLE
Unmark if excluded

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaLaunchConfigurationCacheProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaLaunchConfigurationCacheProvider.kt
@@ -97,7 +97,6 @@ data class AmazonLaunchConfigurationCache(
   }
 
   fun getLaunchConfigsByRegionForImage(params: Parameters): Set<AmazonLaunchConfiguration> {
-    log.debug("getting launch configs in ${javaClass.simpleName}")
     if (params.region != "" && params.id != "") {
       return getRefdAmisForRegion(params.region).getOrDefault(params.id, emptySet())
     } else {
@@ -111,7 +110,6 @@ data class AmazonLaunchConfigurationCache(
    * Returns a map of <K: all ami's referenced by a launch config in region, V: set of launch configs referencing K>
    */
   fun getRefdAmisForRegion(region: String): Map<String, Set<AmazonLaunchConfiguration>> {
-    log.debug("getting refd amis in ${javaClass.simpleName}")
     return refdAmisByRegion[region].orEmpty()
   }
 


### PR DESCRIPTION
Unmark all resources that no longer qualify for a run of marking.

Previously, if a resource was marked and then later qualified to be excluded, the resource would stay marked.

Now, the marked resources should always reflect what currently qualifies.