### PR TITLE
fix(cache): load new caches every refresh

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaEndpointProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaEndpointProvider.kt
@@ -36,4 +36,4 @@ class EddaEndpointProvider(
 @Component
 class EddaEndpointCache(
   eddaEndpointProvider: EddaEndpointProvider
-) : InMemoryCache<EddaEndpoint>(eddaEndpointProvider.load())
+) : InMemoryCache<EddaEndpoint>(eddaEndpointProvider::load)

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaImagesUsedByInstancesProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaImagesUsedByInstancesProvider.kt
@@ -72,7 +72,7 @@ open class EddaImagesUsedByInstancesProvider(
 @Component
 open class EddaImagesUsedByInstancesCache(
   eddaImagesUsedByInstancesProvider: EddaImagesUsedByInstancesProvider
-) : InMemorySingletonCache<AmazonImagesUsedByInstancesCache>(eddaImagesUsedByInstancesProvider.load())
+) : InMemorySingletonCache<AmazonImagesUsedByInstancesCache>(eddaImagesUsedByInstancesProvider::load)
 
 data class AmazonImagesUsedByInstancesCache(
   private val refdAmisByRegion: Map<String, Set<String>>,

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaLaunchConfigurationCacheProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaLaunchConfigurationCacheProvider.kt
@@ -76,7 +76,7 @@ open class EddaLaunchConfigurationCacheProvider(
 @Component
 open class EddaLaunchConfigurationCache(
   eddaLaunchConfigurationCacheProvider: EddaLaunchConfigurationCacheProvider
-) : InMemorySingletonCache<AmazonLaunchConfigurationCache>(eddaLaunchConfigurationCacheProvider.load())
+) : InMemorySingletonCache<AmazonLaunchConfigurationCache>(eddaLaunchConfigurationCacheProvider::load)
 
 data class AmazonLaunchConfigurationCache(
   private val configsByRegion: Map<String, Set<AmazonLaunchConfiguration>>,

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/exclusions/BaseImageLabelsExclusionSupplier.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/exclusions/BaseImageLabelsExclusionSupplier.kt
@@ -71,7 +71,7 @@ class BaseImageLabelsExclusionSupplier(
 class BaseImageLabelsCache(
   gateService: DynamicPropertyService
 ) : InMemoryCache<DynamicProperty>(
-  gateService.getProperties("bakery").propertiesList.toSet()
+  gateService.getProperties("bakery")::getPropertiesList
 )
 
 //TODO: make configurable

--- a/swabbie-clouddriver/src/main/kotlin/com/netflix/spinnaker/swabbie/clouddriver/ClouddriverAccountProvider.kt
+++ b/swabbie-clouddriver/src/main/kotlin/com/netflix/spinnaker/swabbie/clouddriver/ClouddriverAccountProvider.kt
@@ -32,4 +32,4 @@ class ClouddriverAccountProvider(
 @Component
 class ClouddriverAccountCache(
   cloudDriverService: CloudDriverService
-) : InMemoryCache<SpinnakerAccount>(cloudDriverService.getAccounts())
+) : InMemoryCache<SpinnakerAccount>(cloudDriverService::getAccounts)

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Cacheable.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Cacheable.kt
@@ -44,7 +44,7 @@ open class InMemoryCache<out T : Cacheable>(
 
   private val cache = AtomicReference<Set<T>>()
 
-  @Scheduled(initialDelay = 0L, fixedDelay = 15 * 60 * 1000L) //TODO: make configurable
+  @Scheduled(initialDelay = 0L, fixedDelayString = "\${cache.updateIntervalMillis:900000}")
   private fun refresh() {
     try {
       log.info("Refreshing cache ${javaClass.name}")
@@ -72,7 +72,7 @@ open class InMemorySingletonCache<out T : Cacheable>(
 
   private val cache = AtomicReference<T>()
 
-  @Scheduled(initialDelay = 0L, fixedDelay = 15 * 60 * 1000L) //TODO: make configurable
+  @Scheduled(initialDelay = 0L, fixedDelayString = "\${cache.updateIntervalMillis:900000}")
   private fun refresh() {
     try {
       log.info("Refreshing cache ${javaClass.name}")

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Cacheable.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Cacheable.kt
@@ -34,8 +34,9 @@ interface SingletonCache<out T> {
 }
 
 open class InMemoryCache<out T : Cacheable>(
-  private val source: Set<T>
+  private val sourceProvider: () -> Set<T>
 ) : Cache<T> {
+
   override fun contains(key: String?): Boolean {
     if (key == null) return false
     return cache.get().find { it.name == key } != null
@@ -43,11 +44,11 @@ open class InMemoryCache<out T : Cacheable>(
 
   private val cache = AtomicReference<Set<T>>()
 
-  @Scheduled(fixedDelay = 15 * 60 * 1000L) //TODO: make configurable
+  @Scheduled(initialDelay = 0L, fixedDelay = 15 * 60 * 1000L) //TODO: make configurable
   private fun refresh() {
     try {
       log.info("Refreshing cache ${javaClass.name}")
-      cache.set(source)
+      cache.set(sourceProvider.invoke())
     } catch (e: Exception) {
       log.error("Error refreshing cache ${javaClass.name}", e)
     }
@@ -55,7 +56,7 @@ open class InMemoryCache<out T : Cacheable>(
 
   override fun get(): Set<T> {
     if (cache.get() == null) {
-      cache.set(source)
+      cache.set(sourceProvider.invoke())
     }
 
     return cache.get()
@@ -65,17 +66,17 @@ open class InMemoryCache<out T : Cacheable>(
 }
 
 open class InMemorySingletonCache<out T : Cacheable>(
-  private val source: T
+  private val sourceProvider: () -> T
 ) : SingletonCache<T> {
   val log: Logger = LoggerFactory.getLogger(javaClass)
 
   private val cache = AtomicReference<T>()
 
-  @Scheduled(fixedDelay = 15 * 60 * 1000L) //TODO: make configurable
+  @Scheduled(initialDelay = 0L, fixedDelay = 15 * 60 * 1000L) //TODO: make configurable
   private fun refresh() {
     try {
       log.info("Refreshing cache ${javaClass.name}")
-      cache.set(source)
+      cache.set(sourceProvider.invoke())
     } catch (e: Exception) {
       log.error("Error refreshing cache ${javaClass.name}", e)
     }
@@ -83,7 +84,7 @@ open class InMemorySingletonCache<out T : Cacheable>(
 
   override fun get(): T {
     if (cache.get() == null) {
-      cache.set(source)
+      cache.set(sourceProvider.invoke())
     }
     return cache.get()
   }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/services/DynamicPropertyService.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/services/DynamicPropertyService.kt
@@ -27,4 +27,8 @@ interface DynamicPropertyService {
 
 data class PropertyResponse(
   val propertiesList: List<DynamicProperty>
-)
+) {
+  fun getPropertiesList(): Set<DynamicProperty> {
+    return propertiesList.toSet()
+  }
+}

--- a/swabbie-front50/src/main/kotlin/com/netflix/spinnaker/swabbie/front50/Front50ApplicationCache.kt
+++ b/swabbie-front50/src/main/kotlin/com/netflix/spinnaker/swabbie/front50/Front50ApplicationCache.kt
@@ -21,4 +21,4 @@ import com.netflix.spinnaker.swabbie.model.Application
 import org.springframework.stereotype.Component
 
 @Component
-class Front50ApplicationCache(front50Service: Front50Service) : InMemoryCache<Application>(front50Service.getApplications())
+class Front50ApplicationCache(front50Service: Front50Service) : InMemoryCache<Application>(front50Service::getApplications)


### PR DESCRIPTION
In memory caches were only getting refreshed once.
The in memory caches needed to have a function that would refresh the caches, not be passed an object on startup.