### PR TITLE
feat(optOut): tag image with expiration_time:never

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Cacheable.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Cacheable.kt
@@ -39,7 +39,7 @@ open class InMemoryCache<out T : Cacheable>(
 
   override fun contains(key: String?): Boolean {
     if (key == null) return false
-    return cache.get().find { it.name == key } != null
+    return get().find { it.name == key } != null
   }
 
   private val cache = AtomicReference<Set<T>>()

--- a/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaTaskMonitoringAgent.kt
+++ b/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaTaskMonitoringAgent.kt
@@ -197,6 +197,9 @@ class OrcaTaskMonitoringAgent (
             applicationEventPublisher.publishEvent(OptOutResourceEvent(markedResource, taskInfo.workConfiguration))
           }
       }
+      Action.OPTOUT -> {
+        // no action needs to be taken because the status was already updated
+      }
       else -> {
         TODO("Not implemented: event publishing not implemented for action ${taskInfo.action}")
       }

--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
@@ -133,10 +133,12 @@ class ResourceController(
     @PathVariable namespace: String
   ) : ResourceState {
     resourceTrackingRepository.find(resourceId, namespace)?.let { markedResource ->
+      log.debug("Found resource ${markedResource.uniqueId()} to opt out.")
       resourceTrackingRepository.remove(markedResource)
       workConfigurations.find {
         it.namespace.equals(namespace, true)
       }?.also { configuration ->
+        log.debug("Publishing opt out event for ${markedResource.uniqueId()}")
         applicationEventPublisher.publishEvent(OptOutResourceEvent(markedResource, configuration))
       }
     }


### PR DESCRIPTION
- Updating some of the formatting in `ResourceStateManager.updateState(event: Event)` so it's less nested.
- If the event is opt out, also tag the image with `"expiration_time":"never"` so that the opt out status is reflected on the image instead of just stored in the swabbie database.