### PR TITLE
feat(cache): remove info we don't need about launch configs

### DIFF
--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
@@ -191,9 +191,6 @@ object AmazonImageHandlerTest {
     whenever(launchConfigurationCache.get()) doReturn
       AmazonLaunchConfigurationCache(
         mapOf(
-          "us-east-1" to setOf(defaultLaunchConfig)
-        ),
-        mapOf(
           "us-east-1" to mapOf("ami-132" to setOf(defaultLaunchConfig))
         ),
         clock.instant().toEpochMilli(), "default"


### PR DESCRIPTION
We were storing two sets of launch config data. Turns out we only need one set, organized by ami.

@robzienert we're only storing the data we need (https://github.com/spinnaker/swabbie/blob/master/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchconfigurations/LaunchConfiguration.kt#L28), not a ton extra.