### PR TITLE
feat(notif): send app, and send less resource data

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -721,7 +721,8 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
         if (notificationType.equals(Notifier.NotificationType.EMAIL.name, true)) {
           val notificationContext = mapOf(
             "resourceOwner" to owner,
-            "resources" to resources.map { it.slim() }, // todo eb: send less data here than slim
+            "application" to FriggaReflectiveNamer().deriveMoniker(resources.first()).app,
+            "resources" to resources.map { it.barebones() },
             "configuration" to workConfiguration,
             "resourceType" to workConfiguration.resourceType.formatted(),
             "spinnakerLink" to workConfiguration.notificationConfiguration.resourceUrl,

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
@@ -152,12 +152,23 @@ data class MarkedResource(
     )
   }
 
+  fun barebones(): BarebonesMarkedResource {
+    return BarebonesMarkedResource(
+      namespace = namespace,
+      resourceId = resourceId,
+      name = name,
+      projectedDeletionStamp = projectedDeletionStamp,
+      lastSeenInfo = lastSeenInfo,
+      summaries = summaries
+    )
+  }
+
   fun uniqueId(): String {
     return "$namespace:$resourceId"
   }
 }
 
-data class SlimMarkedResource (
+data class SlimMarkedResource(
   override val summaries: List<Summary>,
   override val namespace: String,
   override var projectedSoftDeletionStamp: Long,
@@ -172,6 +183,15 @@ data class SlimMarkedResource (
   override val name: String?,
   override var lastSeenInfo: LastSeenInfo? = null
 ) : MarkedResourceInterface
+
+data class BarebonesMarkedResource(
+  val namespace: String,
+  val resourceId: String,
+  val name: String?,
+  val projectedDeletionStamp: Long,
+  val lastSeenInfo: LastSeenInfo?,
+  val summaries: List<Summary>
+)
 
 data class NotificationInfo(
   val recipient: String? = null,


### PR DESCRIPTION
Adam suggested to show app in the subject. So, parsing it and sending it.
Also, we were sending much more data than needed for the resources. Slimming it down.