### PR TITLE
feat(schedule): deletion timestamp in schedule

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandler.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.swabbie.aws.autoscalinggroups
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer
 import com.netflix.spinnaker.swabbie.AbstractResourceTypeHandler
@@ -54,6 +55,7 @@ class AmazonAutoScalingGroupHandler(
   applicationEventPublisher: ApplicationEventPublisher,
   lockingService: Optional<LockingService>,
   retrySupport: RetrySupport,
+  swabbieProperties: SwabbieProperties,
   private val rules: List<Rule<AmazonAutoScalingGroup>>,
   private val serverGroupProvider: ResourceProvider<AmazonAutoScalingGroup>,
   private val orcaService: OrcaService,
@@ -71,7 +73,8 @@ class AmazonAutoScalingGroupHandler(
   applicationEventPublisher,
   lockingService,
   retrySupport,
-  resourceUseTrackingRepository
+  resourceUseTrackingRepository,
+  swabbieProperties
 ) {
 
   override fun softDeleteResources(markedResources: List<MarkedResource>, workConfiguration: WorkConfiguration) {

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -75,7 +75,8 @@ class AmazonImageHandler(
   applicationEventPublisher,
   lockingService,
   retrySupport,
-  resourceUseTrackingRepository
+  resourceUseTrackingRepository,
+  swabbieProperties
 ) {
 
   override fun deleteResources(markedResources: List<MarkedResource>, workConfiguration: WorkConfiguration) {

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.swabbie.aws.loadbalancers
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer
 import com.netflix.spinnaker.swabbie.*
@@ -48,6 +49,7 @@ class AmazonLoadBalancerHandler(
   applicationEventPublisher: ApplicationEventPublisher,
   lockingService: Optional<LockingService>,
   retrySupport: RetrySupport,
+  swabbieProperties: SwabbieProperties,
   private val rules: List<Rule<AmazonElasticLoadBalancer>>,
   private val loadBalancerProvider: ResourceProvider<AmazonElasticLoadBalancer>,
   private val serverGroupProvider: ResourceProvider<AmazonAutoScalingGroup>,
@@ -66,7 +68,8 @@ class AmazonLoadBalancerHandler(
   applicationEventPublisher,
   lockingService,
   retrySupport,
-  resourceUseTrackingRepository
+  resourceUseTrackingRepository,
+  swabbieProperties
 ) {
   override fun deleteResources(
     markedResources: List<MarkedResource>,

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.swabbie.aws.securitygroups
 
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer
 import com.netflix.spinnaker.swabbie.*
@@ -46,6 +47,7 @@ class AmazonSecurityGroupHandler(
   applicationEventPublisher: ApplicationEventPublisher,
   lockingService: Optional<LockingService>,
   retrySupport: RetrySupport,
+  swabbieProperties: SwabbieProperties,
   private val rules: List<Rule<AmazonSecurityGroup>>,
   private val securityGroupProvider: ResourceProvider<AmazonSecurityGroup>,
   private val orcaService: OrcaService,
@@ -63,7 +65,8 @@ class AmazonSecurityGroupHandler(
   applicationEventPublisher,
   lockingService,
   retrySupport,
-  resourceUseTrackingRepository
+  resourceUseTrackingRepository,
+  swabbieProperties
 ) {
   override fun deleteResources(
     markedResources: List<MarkedResource>,

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandlerTest.kt
@@ -78,7 +78,8 @@ object AmazonAutoScalingGroupHandlerTest {
     retrySupport = RetrySupport(),
     serverGroupProvider = serverGroupProvider,
     orcaService = orcaService,
-    resourceUseTrackingRepository = resourceUseTrackingRepository
+    resourceUseTrackingRepository = resourceUseTrackingRepository,
+    swabbieProperties = SwabbieProperties().also { it.schedule.enabled = false }
   )
 
   @BeforeEach

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
@@ -23,6 +23,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.Attribute
 import com.netflix.spinnaker.config.Exclusion
 import com.netflix.spinnaker.config.ExclusionType
+import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.events.MarkResourceEvent
@@ -622,7 +623,8 @@ object ResourceTypeHandlerTest {
     applicationEventPublisher,
     lockingService,
     retrySupport,
-    resourceUseTrackingRepository
+    resourceUseTrackingRepository,
+    SwabbieProperties()
   ) {
     override fun deleteResources(
       markedResources: List<MarkedResource>,

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ScheduleTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ScheduleTest.kt
@@ -1,0 +1,43 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie
+
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.should.shouldMatch
+import com.netflix.spinnaker.config.Schedule
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+object ScheduleTest {
+  private val subject = Schedule().also { it.enabled = true }
+
+  val mondayTimestamp = Instant.parse("2018-05-21T12:00:00Z")
+  val satTimestamp = Instant.parse("2018-05-26T12:00:00Z")
+  val followingMondayTimestamp = Instant.parse("2018-05-28T12:00:00Z")
+
+  @Test
+  fun `should return timestamp when day is in the schedule`() {
+    subject.getNextTimeInWindow(mondayTimestamp.toEpochMilli()) shouldMatch equalTo(mondayTimestamp.toEpochMilli())
+  }
+
+  @Test
+  fun `should return monday when saturday is the proposed timestamp`() {
+    subject.getNextTimeInWindow(satTimestamp.toEpochMilli()) shouldMatch equalTo(followingMondayTimestamp.toEpochMilli())
+  }
+}


### PR DESCRIPTION
Since swabbie runs on a schedule, the time it schedules the deletion should reflect that schedule. That way, when we notify people, no one is concerned that we are deleting things on a Saturday.