### PR TITLE
fix(agents): surface exceptions, incr metric

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/MetricsSupport.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/MetricsSupport.kt
@@ -52,9 +52,10 @@ open class MetricsSupport(
   protected val restoreCountId: Id = registry.createId("swabbie.resources.restoreCount")
   protected val notifyCountId: Id = registry.createId("swabbie.resources.notifyCount")
   protected val optOutCountId: Id = registry.createId("swabbie.resources.optOutCount")
-  protected val orcaTAskFailureId: Id = registry.createId("swabbie.resources.orcaTaskFailureCount")
+  protected val orcaTaskFailureId: Id = registry.createId("swabbie.resources.orcaTaskFailureCount")
 
   protected val failedAgentId: Id = registry.createId("swabbie.agents.failed")
+  protected val failedDuringSchedule: Id = registry.createId("swabbie.scheduled.failed")
   protected val lastRunAgeId: Id = registry.createId("swabbie.agents.run.age")
 
   protected fun recordMarkMetrics(markerTimerId: Long,

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManager.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManager.kt
@@ -97,7 +97,7 @@ class ResourceStateManager(
       }
 
       is OrcaTaskFailureEvent -> {
-        id = orcaTAskFailureId
+        id = orcaTaskFailureId
         removeTag = false
         msg = generateFailureMessage(event)
         //todo eb: do we want this tagged here?


### PR DESCRIPTION
Ensuring that an exception thrown during execution (for example, during `doMark()`) gets surfaced and logged, and also increments a metric.

Also adding try/catch around scheduled to ensure that it gets rescheduled even if an exception is thrown.