### PR TITLE
feat(owner): adds primary owners

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/AmazonTagOwnerResolutionStrategy.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/AmazonTagOwnerResolutionStrategy.kt
@@ -22,6 +22,9 @@ import org.springframework.stereotype.Component
 
 @Component
 class AmazonTagOwnerResolutionStrategy : ResourceOwnerResolutionStrategy<Resource> {
+
+  override fun primaryFor(): Set<String> = emptySet()
+
   override fun resolve(resource: Resource): String? {
     if ("tags" in resource.details) {
       (resource.details["tags"] as? List<Map<*, *>>)?.let { tags ->

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -628,6 +628,10 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
     }
   }
 
+  /**
+   * Adds the owner to the resourceOwnerField, for each candidate, and if no owner is found it's resolved to the
+   * "defaultDestination", defined in config
+   */
   private fun List<T>.withResolvedOwners(workConfiguration: WorkConfiguration): List<T> =
     this.map { candidate ->
       candidate.apply {

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
@@ -56,6 +56,9 @@ abstract class Resource : Excludable, Timestamped, HasDetails() {
       set(name, value)
     }
 
+  fun toLog() =
+    "$resourceId:$resourceType"
+
   override fun equals(other: Any?): Boolean {
     if (this === other) {
       return true

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceOwnerResolverTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceOwnerResolverTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.swabbie
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.should.shouldMatch
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.swabbie.model.Resource
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+object ResourceOwnerResolverTest {
+
+  private val resource = TestResource("1")
+  private val secondResource = TestResource(id = "2", resourceType = "type")
+
+  @Test
+  fun `should resolve to single owner`() {
+    val subject = ResourceOwnerResolver(NoopRegistry(), listOf(ConstantStrategy()))
+    subject.resolve(resource) shouldMatch equalTo("swabbie@swabbie.io")
+  }
+
+  @Test
+  fun `should resolve to null owner`() {
+    val subject = ResourceOwnerResolver(NoopRegistry(), listOf(NoopStrategy()))
+    assert(subject.resolve(resource) == null)
+  }
+
+  @Test
+  fun `should pick primary owner`() {
+    val subject = ResourceOwnerResolver(NoopRegistry(), listOf(ConstantStrategy(), TestStrategy()))
+    subject.resolve(resource) shouldMatch equalTo("test@netflix.com")
+  }
+
+  @Test
+  fun `should return multiple owners`() {
+    val subject = ResourceOwnerResolver(NoopRegistry(), listOf(ConstantStrategy(), TestStrategy()))
+    subject.resolve(secondResource) shouldMatch equalTo("swabbie@swabbie.io,ohwow@netflix.com")
+  }
+}
+
+class NoopStrategy : ResourceOwnerResolutionStrategy<Resource> {
+  override fun resolve(resource: Resource): String? = null
+  override fun primaryFor(): Set<String> = emptySet()
+}
+
+class ConstantStrategy : ResourceOwnerResolutionStrategy<Resource> {
+  override fun resolve(resource: Resource): String? = "swabbie@swabbie.io"
+  override fun primaryFor(): Set<String> = emptySet()
+}
+
+class TestStrategy : ResourceOwnerResolutionStrategy<Resource> {
+  override fun resolve(resource: Resource): String? {
+    return if (resource.resourceId == "1") {
+      "test@netflix.com"
+    } else {
+      "ohwow@netflix.com"
+    }
+  }
+  override fun primaryFor(): Set<String> = setOf("image")
+}
+
+@JsonTypeName("Test")
+data class TestResource(
+    private val id: String,
+    override val resourceId: String = id,
+    override val name: String = "name",
+    override val resourceType: String = "image",
+    override val cloudProvider: String = "provider",
+    override val createTs: Long = Instant.parse("2018-05-24T12:34:56Z").toEpochMilli()
+) : Resource()

--- a/swabbie-front50/src/main/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategy.kt
+++ b/swabbie-front50/src/main/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategy.kt
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.swabbie.front50
 
-import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer
 import com.netflix.spinnaker.swabbie.InMemoryCache
@@ -34,6 +33,8 @@ class ApplicationResourceOwnerResolutionStrategy(
 ) : ResourceOwnerResolutionStrategy<Resource> {
   private val log: Logger = LoggerFactory.getLogger(this.javaClass)
   private val resourceOwnerId = registry.createId("swabbie.resources.owner")
+
+  override fun primaryFor(): Set<String> = emptySet()
 
   override fun resolve(resource: Resource): String? {
     val applicationToOwnersPairs = mutableSetOf<Pair<String?, String?>>()


### PR DESCRIPTION
There are multiple ways an owner can be resolved - the application, the amazon tag, etc. Some of those ways are more reliable than others. This PR adds support for saying one resolver can provide all the ownership info needed for a resource.

This PR will be built on with a strategy for Netflix allowing an internal tool to provide "primary" ownership. If that tool does not have information about a resource, any other ownership information will be used.