### PR TITLE
feat(cache): wait for caches to fill before working

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CacheStatus.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CacheStatus.kt
@@ -7,11 +7,15 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
+interface CacheStatus {
+  abstract fun cachesLoaded(): Boolean
+}
+
 @Component
-class CacheStatus(
+open class InMemoryCacheStatus(
   private val caches: List<Cache<*>>,
   private val singletonCaches: List<SingletonCache<*>>
-) {
+): CacheStatus {
   private var allLoaded = AtomicReference<Boolean>(false)
   private val executorService = Executors.newSingleThreadScheduledExecutor()
   private val log: Logger = LoggerFactory.getLogger(javaClass)
@@ -55,7 +59,11 @@ class CacheStatus(
     }
   }
 
-  fun cachesLoaded(): Boolean {
+  override fun cachesLoaded(): Boolean {
     return allLoaded.get()
   }
+}
+
+open class NoopCacheStatus: CacheStatus {
+  override fun cachesLoaded() = true
 }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CacheStatus.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CacheStatus.kt
@@ -1,0 +1,61 @@
+package com.netflix.spinnaker.swabbie
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+@Component
+class CacheStatus(
+  private val caches: List<Cache<*>>,
+  private val singletonCaches: List<SingletonCache<*>>
+) {
+  private var allLoaded = AtomicReference<Boolean>(false)
+  private val executorService = Executors.newSingleThreadScheduledExecutor()
+  private val log: Logger = LoggerFactory.getLogger(javaClass)
+
+  init {
+    executorService.scheduleWithFixedDelay({
+      try {
+        if (!allLoaded.get()) {
+          log.debug("All caches not loaded, checking cache status.")
+          updateStatus()
+        } else {
+          log.debug("All caches loaded")
+          shutdown()
+        }
+      } catch (e: Exception) {
+        log.error("Failed while checking the caches in ${javaClass.simpleName}.")
+      }
+    }, 0, 5, TimeUnit.SECONDS)
+  }
+
+  private fun updateStatus() {
+    caches.forEach { cache ->
+      if (!cache.loadingComplete()) return
+    }
+
+    singletonCaches.forEach { cache ->
+      if (!cache.loadingComplete()) return
+    }
+
+    allLoaded.set(true)
+  }
+
+  private fun shutdown() {
+    executorService.shutdown()
+    try {
+      if (!executorService.awaitTermination(800, TimeUnit.MILLISECONDS)) {
+        executorService.shutdownNow()
+      }
+    } catch (e: InterruptedException) {
+      executorService.shutdownNow()
+    }
+  }
+
+  fun cachesLoaded(): Boolean {
+    return allLoaded.get()
+  }
+}

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Cacheable.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Cacheable.kt
@@ -27,15 +27,19 @@ interface Cacheable : Named
 interface Cache<out T> {
   fun get(): Set<T>
   fun contains(key: String?): Boolean
+  fun loadingComplete(): Boolean
 }
 
 interface SingletonCache<out T> {
   fun get(): T
+  fun loadingComplete(): Boolean
 }
 
 open class InMemoryCache<out T : Cacheable>(
   private val sourceProvider: () -> Set<T>
 ) : Cache<T> {
+
+  val log: Logger = LoggerFactory.getLogger(javaClass)
 
   override fun contains(key: String?): Boolean {
     if (key == null) return false
@@ -62,7 +66,9 @@ open class InMemoryCache<out T : Cacheable>(
     return cache.get()
   }
 
-  val log: Logger = LoggerFactory.getLogger(javaClass)
+  override fun loadingComplete(): Boolean {
+    return cache.get() != null
+  }
 }
 
 open class InMemorySingletonCache<out T : Cacheable>(
@@ -87,5 +93,9 @@ open class InMemorySingletonCache<out T : Cacheable>(
       cache.set(sourceProvider.invoke())
     }
     return cache.get()
+  }
+
+  override fun loadingComplete(): Boolean {
+    return cache.get() != null
   }
 }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/NotificationAgent.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/NotificationAgent.kt
@@ -42,6 +42,7 @@ class NotificationAgent(
   workConfigurations: List<WorkConfiguration>,
   agentExecutor: Executor,
   swabbieProperties: SwabbieProperties,
+  cacheStatus: CacheStatus,
   private val clock: Clock
 ) : ScheduledAgent(
   clock,
@@ -49,7 +50,8 @@ class NotificationAgent(
   resourceTypeHandlers,
   workConfigurations,
   agentExecutor,
-  swabbieProperties
+  swabbieProperties,
+  cacheStatus
 ) {
   @Value("\${swabbie.agents.notify.intervalSeconds:3600}")
   private var interval: Long = 3600

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceCleanerAgent.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceCleanerAgent.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.swabbie.agents
 
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.SwabbieProperties
+import com.netflix.spinnaker.swabbie.CacheStatus
 import com.netflix.spinnaker.swabbie.ResourceTypeHandler
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
@@ -41,6 +42,7 @@ class ResourceCleanerAgent(
   workConfigurations: List<WorkConfiguration>,
   agentExecutor: Executor,
   swabbieProperties: SwabbieProperties,
+  cacheStatus: CacheStatus,
   private val clock: Clock
 ) : ScheduledAgent(
   clock,
@@ -48,7 +50,8 @@ class ResourceCleanerAgent(
   resourceTypeHandlers,
   workConfigurations,
   agentExecutor,
-  swabbieProperties
+  swabbieProperties,
+  cacheStatus
 ) {
   @Value("\${swabbie.agents.clean.intervalSeconds:3600}")
   private var interval: Long = 3600

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceMarkerAgent.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceMarkerAgent.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.swabbie.agents
 
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.SwabbieProperties
+import com.netflix.spinnaker.swabbie.CacheStatus
 import com.netflix.spinnaker.swabbie.ResourceTypeHandler
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
@@ -41,6 +42,7 @@ class ResourceMarkerAgent(
   workConfigurations: List<WorkConfiguration>,
   agentExecutor: Executor,
   swabbieProperties: SwabbieProperties,
+  cacheStatus: CacheStatus,
   private val clock: Clock
 ) : ScheduledAgent(
   clock,
@@ -48,7 +50,8 @@ class ResourceMarkerAgent(
   resourceTypeHandlers,
   workConfigurations,
   agentExecutor,
-  swabbieProperties
+  swabbieProperties,
+  cacheStatus
 ) {
   @Value("\${swabbie.agents.mark.intervalSeconds:3600}")
   private var interval: Long = 3600

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceSoftDeleteAgent.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceSoftDeleteAgent.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.swabbie.agents
 
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.SwabbieProperties
+import com.netflix.spinnaker.swabbie.CacheStatus
 import com.netflix.spinnaker.swabbie.ResourceTypeHandler
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
@@ -41,6 +42,7 @@ class ResourceSoftDeleteAgent(
   workConfigurations: List<WorkConfiguration>,
   agentExecutor: Executor,
   swabbieProperties: SwabbieProperties,
+  cacheStatus: CacheStatus,
   private val clock: Clock
 ) : ScheduledAgent(
   clock,
@@ -48,7 +50,8 @@ class ResourceSoftDeleteAgent(
   resourceTypeHandlers,
   workConfigurations,
   agentExecutor,
-  swabbieProperties
+  swabbieProperties,
+  cacheStatus
 ) {
   @Value("\${swabbie.agents.softDelete.intervalSeconds:3600}")
   private var interval: Long = 3600

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/agents/NotificationAgentTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/agents/NotificationAgentTest.kt
@@ -18,9 +18,12 @@ package com.netflix.spinnaker.swabbie.agents
 
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.SwabbieProperties
+import com.netflix.spinnaker.swabbie.CacheStatus
+import com.netflix.spinnaker.swabbie.NoopCacheStatus
 import com.netflix.spinnaker.swabbie.ResourceTypeHandler
 import com.netflix.spinnaker.swabbie.ResourceTypeHandlerTest.workConfiguration
 import com.nhaarman.mockito_kotlin.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
 
@@ -30,6 +33,7 @@ object NotificationAgentTest {
   private val configuration = workConfiguration()
   private val agentExecutor = BlockingThreadExecutor()
   private val swabbieProperties = SwabbieProperties()
+  private val cacheStatus = NoopCacheStatus()
 
   @Test
   fun `should not notify if no handler found`() {
@@ -42,7 +46,8 @@ object NotificationAgentTest {
       resourceTypeHandlers = listOf(resourceTypeHandler),
       workConfigurations = listOf(configuration),
       agentExecutor = agentExecutor,
-      swabbieProperties = swabbieProperties
+      swabbieProperties = swabbieProperties,
+      cacheStatus = cacheStatus
     ).process(configuration, onCompleteCallback)
 
     verify(resourceTypeHandler, never()).notify(any(), any())
@@ -59,7 +64,8 @@ object NotificationAgentTest {
       clock = clock,
       workConfigurations = listOf(configuration),
       agentExecutor = agentExecutor,
-      swabbieProperties = swabbieProperties
+      swabbieProperties = swabbieProperties,
+      cacheStatus = cacheStatus
     ).process(configuration, onCompleteCallback)
 
     verify(resourceTypeHandler, times(1)).notify(

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceMarkerAgentTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceMarkerAgentTest.kt
@@ -19,10 +19,13 @@ package com.netflix.spinnaker.swabbie.agents
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.lock.LockManager
+import com.netflix.spinnaker.swabbie.CacheStatus
+import com.netflix.spinnaker.swabbie.NoopCacheStatus
 import com.netflix.spinnaker.swabbie.ResourceTypeHandler
 import com.netflix.spinnaker.swabbie.ResourceTypeHandlerTest.workConfiguration
 import com.nhaarman.mockito_kotlin.*
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.util.concurrent.CountDownLatch
@@ -40,6 +43,7 @@ object ResourceMarkerAgentTest {
   fun cleanup() {
     reset(lockManager)
   }
+  private val cacheStatus = NoopCacheStatus()
 
   @Test
   fun `should do nothing if no handler is found for configuration`() {
@@ -52,7 +56,8 @@ object ResourceMarkerAgentTest {
       resourceTypeHandlers = listOf(resourceTypeHandler),
       workConfigurations = listOf(configuration),
       agentExecutor = agentExecutor,
-      swabbieProperties = SwabbieProperties()
+      swabbieProperties = SwabbieProperties(),
+      cacheStatus = cacheStatus
     ).process(configuration, onCompleteCallback)
 
     verify(resourceTypeHandler, never()).mark(any(), any())
@@ -69,7 +74,8 @@ object ResourceMarkerAgentTest {
       resourceTypeHandlers = listOf(resourceTypeHandler),
       workConfigurations = listOf(configuration),
       agentExecutor = agentExecutor,
-      swabbieProperties = SwabbieProperties()
+      swabbieProperties = SwabbieProperties(),
+      cacheStatus = cacheStatus
     ).process(configuration, onCompleteCallback)
 
     verify(resourceTypeHandler).mark(any(), any())


### PR DESCRIPTION
Before the agents start to mark a resource, all caches should fill. This PR adds support for that.