### PR TITLE
fix(redis): hydrating all values not just first 100

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -667,6 +667,8 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
         return
       }
 
+      log.info("Processing ${markedResources.size} for notification in ${javaClass.simpleName}")
+
       val maxItemsToProcess = Math.min(markedResources.size, workConfiguration.maxItemsProcessedPerCycle)
       markedResources.subList(0, maxItemsToProcess)
         .filter {

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CacheStatus.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CacheStatus.kt
@@ -31,7 +31,7 @@ open class InMemoryCacheStatus(
           shutdown()
         }
       } catch (e: Exception) {
-        log.error("Failed while checking the caches in ${javaClass.simpleName}.")
+        log.error("Failed while checking the caches in ${javaClass.simpleName}.", e)
       }
     }, 0, 5, TimeUnit.SECONDS)
   }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ScheduledAgent.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ScheduledAgent.kt
@@ -79,7 +79,7 @@ abstract class ScheduledAgent(
          startupExecutorService.shutdown()
        }
      } catch (e: Exception) {
-       log.error("Failed while waiting for cache to start in ${javaClass.simpleName}.")
+       log.error("Failed while waiting for cache to start in ${javaClass.simpleName}.", e)
      }
     }, 0, 5, TimeUnit.SECONDS)
   }


### PR DESCRIPTION
Bug: when hydrating, the redis repositories would only return the first `REDIS_CHUNK_SIZE` resources. This fixes that problem.