### PR TITLE
feat(deleted): list vew for marked and deleted resources

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/ResourceTrackingRepository.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/ResourceTrackingRepository.kt
@@ -37,5 +37,13 @@ interface ResourceTrackingRepository {
 
   fun getNumMarkedResources(): Long
 
+  fun getDeleted(): List<DeleteInfo>
+
   fun find(resourceId: String, namespace: String): MarkedResource?
 }
+
+data class DeleteInfo(
+  val name: String,
+  val resourceId: String,
+  val namespace: String
+)

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/agents/NotificationAgentTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/agents/NotificationAgentTest.kt
@@ -18,12 +18,10 @@ package com.netflix.spinnaker.swabbie.agents
 
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.SwabbieProperties
-import com.netflix.spinnaker.swabbie.CacheStatus
 import com.netflix.spinnaker.swabbie.NoopCacheStatus
 import com.netflix.spinnaker.swabbie.ResourceTypeHandler
 import com.netflix.spinnaker.swabbie.ResourceTypeHandlerTest.workConfiguration
 import com.nhaarman.mockito_kotlin.*
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
 

--- a/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceTrackingRepositoryTest.kt
+++ b/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceTrackingRepositoryTest.kt
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.swabbie.model.*
 import com.netflix.spinnaker.swabbie.test.TestResource
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import com.netflix.spinnaker.swabbie.repository.DeleteInfo
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -238,5 +239,14 @@ object RedisResourceTrackingRepositoryTest {
 
     resourceRepository.getNumMarkedResources() shouldMatch equalTo(200L)
     resourceRepository.getMarkedResources().size shouldMatch equalTo(200)
+  }
+
+  @Test
+  fun `should store a list of deleted resources`() {
+    resourceRepository.upsert(defaultMarkedResource)
+    resourceRepository.remove(defaultMarkedResource)
+
+    resourceRepository.getMarkedResources() shouldMatch equalTo(emptyList())
+    resourceRepository.getDeleted() shouldMatch equalTo(listOf(DeleteInfo("test", "test", "namespace")))
   }
 }


### PR DESCRIPTION
Adding endpoints to get a list of everything marked and deleted (sorted by name, which will be the most useful for teams checking this list to see if their package is being deleted).

Adding this after the Titus and Database teams gave feedback that they really wanted notifications, or at least some record they could look at to see if their packages were going to be cleaned up/had been cleaned up.