### PR TITLE
feat(grouping): add grouping (like app) to resources

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
@@ -78,7 +78,7 @@ class AmazonSecurityGroupHandler(
           log.info("This resource is about to be deleted {}", markedResource)
           orcaService.orchestrate(
             OrchestrationRequest(
-              application = FriggaReflectiveNamer().deriveMoniker(markedResource).app,
+              application = determineApp(resource),
               job = listOf(
                 OrcaJob(
                   type = "deleteSecurityGroup",
@@ -91,7 +91,7 @@ class AmazonSecurityGroupHandler(
                   )
                 )
               ),
-              description = "Cleaning up Security Group for ${FriggaReflectiveNamer().deriveMoniker(markedResource).app}"
+              description = "Cleaning up Security Group for ${resource.grouping?.value.orEmpty()}"
             )
           ).let { taskResponse ->
             taskTrackingRepository.add(
@@ -107,6 +107,14 @@ class AmazonSecurityGroupHandler(
         }
       }
     }
+  }
+
+  private fun determineApp(resource: Resource): String {
+    val grouping: Grouping = resource.grouping?: return "swabbie"
+    if (grouping.type == GroupingType.APPLICATION) {
+      return grouping.value
+    }
+    return "swabbie"
   }
 
   override fun softDeleteResources(markedResources: List<MarkedResource>, workConfiguration: WorkConfiguration) {

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
@@ -40,6 +40,7 @@ import com.netflix.spinnaker.swabbie.orca.OrcaService
 import com.netflix.spinnaker.swabbie.orca.TaskResponse
 import com.netflix.spinnaker.swabbie.repository.*
 import com.netflix.spinnaker.swabbie.tagging.TaggingService
+import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
 import com.nhaarman.mockito_kotlin.*
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
@@ -63,7 +64,6 @@ object AmazonImageHandlerTest {
   private val imageProvider = mock<ResourceProvider<AmazonImage>>()
   private val instanceProvider = mock<ResourceProvider<AmazonInstance>>()
   private val launchConfigurationProvider = mock<ResourceProvider<AmazonLaunchConfiguration>>()
-  private val applicationsCache = mock<InMemoryCache<Application>>()
   private val taggingService = mock<TaggingService>()
   private val taskTrackingRepository = mock<TaskTrackingRepository>()
   private val resourceUseTrackingRepository = mock<ResourceUseTrackingRepository>()
@@ -73,6 +73,7 @@ object AmazonImageHandlerTest {
   }
   private val launchConfigurationCache = mock<InMemorySingletonCache<AmazonLaunchConfigurationCache>>()
   private val imagesUsedByinstancesCache = mock<InMemorySingletonCache<AmazonImagesUsedByInstancesCache>>()
+  private val applicationUtils = ApplicationUtils(emptyList())
 
   private val subject = AmazonImageHandler(
     clock = clock,
@@ -92,13 +93,13 @@ object AmazonImageHandlerTest {
     retrySupport = RetrySupport(),
     imageProvider = imageProvider,
     orcaService = orcaService,
-    applicationsCaches = listOf(applicationsCache),
     taggingService = taggingService,
     taskTrackingRepository = taskTrackingRepository,
     resourceUseTrackingRepository = resourceUseTrackingRepository,
     swabbieProperties = swabbieProperties,
     launchConfigurationCache = launchConfigurationCache,
-    imagesUsedByinstancesCache = imagesUsedByinstancesCache
+    imagesUsedByinstancesCache = imagesUsedByinstancesCache,
+    applicationUtils = applicationUtils
   )
 
   @BeforeEach

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ScheduledAgent.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/agents/ScheduledAgent.kt
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory
 import java.time.*
 import java.time.temporal.Temporal
 import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import javax.annotation.PostConstruct
@@ -76,12 +77,23 @@ abstract class ScheduledAgent(
        } else {
          log.debug("Caches loaded.")
          scheduleSwabbie()
-         startupExecutorService.shutdown()
+         shutdown(startupExecutorService)
        }
      } catch (e: Exception) {
        log.error("Failed while waiting for cache to start in ${javaClass.simpleName}.", e)
      }
     }, 0, 5, TimeUnit.SECONDS)
+  }
+
+  private fun shutdown(executorService: ExecutorService) {
+    executorService.shutdown()
+    try {
+      if (!executorService.awaitTermination(800, TimeUnit.MILLISECONDS)) {
+        executorService.shutdownNow()
+      }
+    } catch (e: InterruptedException) {
+      executorService.shutdownNow()
+    }
   }
 
   private fun scheduleSwabbie() {

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Account.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Account.kt
@@ -45,7 +45,8 @@ data class SpinnakerAccount(
   override val name: String,
   override val edda: String?,
   override val regions: List<Region>?,
-  override val environment: String
+  override val environment: String,
+  override val grouping: Grouping? = null
 ) : Account, Cacheable, HasDetails() {
   override val resourceId: String
     get() = accountId!!
@@ -62,7 +63,8 @@ data class EmptyAccount(
   override val eddaEnabled: Boolean = false,
   override val edda: String? = "",
   override val regions: List<Region> = emptyList(),
-  override val environment: String = ""
+  override val environment: String = "",
+  override val grouping: Grouping? = null
 ) : Account, HasDetails() {
   override val resourceId: String
     get() = accountId!!

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Application.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Application.kt
@@ -29,4 +29,6 @@ data class Application(
     get() = "application"
   override val cloudProvider: String
     get() = "*"
+  override val grouping: Grouping?
+    get() = Grouping(name, GroupingType.APPLICATION)
 }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/utils/ApplicationUtils.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/utils/ApplicationUtils.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.swabbie.utils
+
+import com.netflix.spinnaker.swabbie.InMemoryCache
+import com.netflix.spinnaker.swabbie.model.*
+import org.springframework.stereotype.Component
+
+@Component
+open class ApplicationUtils(
+  private val applicationsCaches: List<InMemoryCache<Application>>
+) {
+
+  /**
+   * If the resource has an app grouping and that app exists in the cache of applicaitons we know about,
+   *  return that app.
+   * Otherwise, return "swabbie".
+   */
+  fun determineApp(resource: Resource): String {
+    val grouping: Grouping = resource.grouping?: return "swabbie"
+    if (grouping.type == GroupingType.APPLICATION) {
+      if (applicationsCaches.any { it.contains(grouping.value) }) {
+        return grouping.value
+      }
+    }
+    return "swabbie"
+  }
+}

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceOwnerResolverTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceOwnerResolverTest.kt
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.should.shouldMatch
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.swabbie.model.Grouping
+import com.netflix.spinnaker.swabbie.model.GroupingType
 import com.netflix.spinnaker.swabbie.model.Resource
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -82,5 +84,6 @@ data class TestResource(
     override val name: String = "name",
     override val resourceType: String = "image",
     override val cloudProvider: String = "provider",
-    override val createTs: Long = Instant.parse("2018-05-24T12:34:56Z").toEpochMilli()
+    override val createTs: Long = Instant.parse("2018-05-24T12:34:56Z").toEpochMilli(),
+    override val grouping: Grouping? = Grouping("group", GroupingType.APPLICATION)
 ) : Resource()

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManagerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManagerTest.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.swabbie.model.*
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.tagging.TaggingService
 import com.netflix.spinnaker.swabbie.test.TestResource
+import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
 import com.nhaarman.mockito_kotlin.*
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -40,12 +41,9 @@ object ResourceStateManagerTest {
   private val taggingService = mock<TaggingService>()
   private val taskTrackingRepository = mock<TaskTrackingRepository>()
 
-  private val app = Application(name = "testapp", email = "test@test.com")
-  private val inMemCache = InMemoryCache {setOf(app)}
-  private val applicationsCaches = listOf(inMemCache)
-
   private var resource = TestResource("testResource")
   private var configuration = workConfiguration()
+  private val applicationUtils = ApplicationUtils(emptyList())
 
   private val markedResourceWithViolations =  MarkedResource(
     resource = resource,
@@ -70,7 +68,7 @@ object ResourceStateManagerTest {
     resourceTagger = resourceTagger,
     taggingService = taggingService,
     taskTrackingRepository = taskTrackingRepository,
-    applicationsCaches = applicationsCaches
+    applicationUtils = applicationUtils
   )
 
   @AfterEach

--- a/swabbie-front50/src/test/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategyTest.kt
+++ b/swabbie-front50/src/test/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategyTest.kt
@@ -22,6 +22,8 @@ import com.natpryce.hamkrest.should.shouldMatch
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.swabbie.InMemoryCache
 import com.netflix.spinnaker.swabbie.model.Application
+import com.netflix.spinnaker.swabbie.model.Grouping
+import com.netflix.spinnaker.swabbie.model.GroupingType
 import com.netflix.spinnaker.swabbie.model.Resource
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
@@ -42,17 +44,6 @@ object ApplicationResourceOwnerResolutionStrategyTest {
 
     subject.resolve(ResourceOne()) shouldMatch equalTo("name@netflix.com")
   }
-
-  @Test
-  fun `should resolve multiple resource owner from spinnaker application`() {
-    whenever(front50ApplicationCache.get()) doReturn
-      setOf(
-        Application(name = "name", email = "name@netflix.com"),
-        Application(name = "test", email = "test@netflix.com")
-      )
-
-    subject.resolve(ResourceOne()) shouldMatch equalTo("name@netflix.com")
-  }
 }
 
 @JsonTypeName("R")
@@ -61,5 +52,6 @@ data class ResourceOne(
   override val name: String = "name",
   override val resourceType: String = "type",
   override val cloudProvider: String = "provider",
-  override val createTs: Long = System.currentTimeMillis()
+  override val createTs: Long = System.currentTimeMillis(),
+  override val grouping: Grouping? = Grouping(name, GroupingType.APPLICATION)
 ) : Resource()

--- a/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/TestResource.kt
+++ b/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/TestResource.kt
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.swabbie.test
 
 import com.fasterxml.jackson.annotation.JsonTypeName
+import com.netflix.spinnaker.swabbie.model.Grouping
+import com.netflix.spinnaker.swabbie.model.GroupingType
 import com.netflix.spinnaker.swabbie.model.Resource
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -27,7 +29,8 @@ data class TestResource(
   override val resourceType: String = TEST_RESOURCE_TYPE,
   override val cloudProvider: String = TEST_RESOURCE_PROVIDER_TYPE,
   override val name: String = resourceId,
-  override val createTs: Long = Instant.now().minus(10, ChronoUnit.DAYS).toEpochMilli()
+  override val createTs: Long = Instant.now().minus(10, ChronoUnit.DAYS).toEpochMilli(),
+  override val grouping: Grouping? = Grouping("group", GroupingType.APPLICATION)
 ) : Resource()
 
 const val TEST_RESOURCE_PROVIDER_TYPE = "testProvider"


### PR DESCRIPTION
We can't parse app name from image name. We can only parse package name.

This PR introduces a "grouping" field on an excludable (an image, an application), and defines the value and what type it is. For example, a deb called "spinredis-server-0.0.1" would be grouped by the `PACKAGE_NAME` `spinredis-server`. Because this grouping is not `APPLICATION`, the `Front50ApplicationExclusionPolicy` cannot provide any ownership about it, and now returns null (null == should not exclude).

This grouping is used when we group resources together (to send notifications) and to submit task to orca (for deletion, now all tasks will show up in the swabbie app).

For things that don't have grouping (resources marked before this PR is merged), tasks will appear under "swabbie" app and emails will be sent with no "application". This is fine, as we're sending all notifications to the "default owner" for now, until we can turn off notifications for emails entirely.

This PR also reformats some more kotlin-style nested blocks into more java-style intermediate variables.