### PR TITLE
feat(optOut): opt out resource even if we didn't mark it yet

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandler.kt
@@ -61,6 +61,11 @@ interface ResourceTypeHandler<T : Resource> {
   fun delete(workConfiguration: WorkConfiguration, postDelete: () -> Unit)
 
   /**
+   * Opts a resource out whether or not it has been marked.
+   */
+  fun optOut(resourceId: String, workConfiguration: WorkConfiguration)
+
+  /**
    * Used to check references and augment candidates for further processing
    * Impl should prefer this interface and avoid I/O in [Rule]
    * A rule should leverage metadata added by this function.


### PR DESCRIPTION
We want to let people opt out (aka tag their image with `"expiration_time":"never"`) even if we haven't marked it yet. 

This updates the opt out api to add that functionality. 