### PR TITLE
chore(timeout) bump orca task timeout for delete

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -91,7 +91,7 @@ class AmazonImageHandler(
               "imageIds" to markedResources.map { it.resourceId }.toSet(),
               "cloudProvider" to AWS,
               "region" to workConfiguration.location,
-              "stageTimeoutMs" to Duration.ofMinutes(15).toMillis().toString()
+              "stageTimeoutMs" to Duration.ofMinutes(40).toMillis().toString()
             )
           )
         ),

--- a/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaTaskMonitoringAgent.kt
+++ b/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaTaskMonitoringAgent.kt
@@ -143,10 +143,11 @@ class OrcaTaskMonitoringAgent (
             }
             response.status.isFailure() -> {
               log.error(
-                "Orca task {} did not complete. Status: {}. Task complete info: {}",
+                "Orca task {} for action {} did not complete. Status: {}. Resources: {}",
                 kv("taskId", taskId),
+                taskInfo.action,
                 kv("responseStatus", response.status),
-                taskInfo
+                taskInfo.markedResources.map { it.uniqueId() }
               )
               taskTrackingRepository.setFailed(taskId)
               taskInfo.markedResources


### PR DESCRIPTION
Right now, the orca tasks are timing out when we delete images. If the tasks fail, we never increment the metric that says we've deleted the images (because the `DeleteResourceEvent` is never fired: https://github.com/spinnaker/swabbie/blob/master/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaTaskMonitoringAgent.kt#L141).

I want this metric to be published, and the resources to be removed from the marked list right after they're deleted. Should I:
- bump the timeout (this PR does that) so that we monitor the task for longer
- publish the event anyways even if the orca task fails (or parse more of the orca json to figure out if it was a timeout failure, and only publish the event on timeout failures)
- not care about tracking the orca task at all, because if the resource didn't get deleted because of a transient orca failure we would just try again next time? 

(also simplifying a log message in this PR)