### PR TITLE
chore(timeout) remove orca task timeout for delete

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -90,8 +90,7 @@ class AmazonImageHandler(
               "credentials" to workConfiguration.account.name,
               "imageIds" to markedResources.map { it.resourceId }.toSet(),
               "cloudProvider" to AWS,
-              "region" to workConfiguration.location,
-              "stageTimeoutMs" to Duration.ofMinutes(15).toMillis().toString()
+              "region" to workConfiguration.location
             )
           )
         ),

--- a/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaTaskMonitoringAgent.kt
+++ b/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaTaskMonitoringAgent.kt
@@ -143,10 +143,11 @@ class OrcaTaskMonitoringAgent (
             }
             response.status.isFailure() -> {
               log.error(
-                "Orca task {} did not complete. Status: {}. Task complete info: {}",
+                "Orca task {} for action {} did not complete. Status: {}. Resources: {}",
                 kv("taskId", taskId),
+                taskInfo.action,
                 kv("responseStatus", response.status),
-                taskInfo
+                taskInfo.markedResources.map { it.uniqueId() }
               )
               taskTrackingRepository.setFailed(taskId)
               taskInfo.markedResources


### PR DESCRIPTION
Remove timeout override for orca delete task (because we are no longer monitoring delete: https://github.com/spinnaker/orca/pull/2520). 

Updating log message in orca task monitor to be shorter.