### PR TITLE
fix(time): deletion time is now + retention period, not more

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -39,14 +39,11 @@ import com.netflix.spinnaker.swabbie.repository.ResourceUseTrackingRepository
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
-import java.time.Clock
-import java.time.Instant
-import java.time.LocalDate
-import java.time.Period
-import java.time.ZoneId
+import java.time.*
 import java.time.temporal.ChronoUnit
 import java.time.temporal.ChronoUnit.DAYS
 import java.util.Optional
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 abstract class AbstractResourceTypeHandler<T : Resource>(
@@ -378,9 +375,10 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
     }
   }
 
-  private fun deletionTimestamp(workConfiguration: WorkConfiguration): Long {
-    val daysInFuture = workConfiguration.retention + 1
-    val proposedTime = daysInFuture.days.fromNow.atStartOfDay(clock.zone).toInstant().toEpochMilli()
+  fun deletionTimestamp(workConfiguration: WorkConfiguration): Long {
+    val daysInFuture = workConfiguration.retention.toLong()
+    val seconds = TimeUnit.DAYS.toSeconds(daysInFuture)
+    val proposedTime = clock.instant().plusSeconds(seconds).toEpochMilli()
     return swabbieProperties.schedule.getNextTimeInWindow(proposedTime)
   }
 

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceMarkerAgentTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/agents/ResourceMarkerAgentTest.kt
@@ -19,21 +19,21 @@ package com.netflix.spinnaker.swabbie.agents
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.lock.LockManager
-import com.netflix.spinnaker.swabbie.CacheStatus
 import com.netflix.spinnaker.swabbie.NoopCacheStatus
 import com.netflix.spinnaker.swabbie.ResourceTypeHandler
 import com.netflix.spinnaker.swabbie.ResourceTypeHandlerTest.workConfiguration
 import com.nhaarman.mockito_kotlin.*
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
 object ResourceMarkerAgentTest {
-  private val clock = Clock.systemDefaultZone()
+  private val clock = Clock.fixed(Instant.parse("2018-05-24T09:30:00Z"), ZoneOffset.UTC)
   private val lockManager = mock<LockManager>()
   private val configuration = workConfiguration()
   private val agentExecutor = BlockingThreadExecutor()


### PR DESCRIPTION
Using `atStartOfDay()` gives a weird time that ends up being around `16:30` instead of at the actual start of day.

Updating the deletion timestamp to just add the retention period of days.