### PR TITLE
feat(deleteTime): recalculate time for some resources

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -321,8 +321,8 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
     }
   }
 
-  override fun recalculateDeletionTimestamp(retentionS: Long, numResources: Int) {
-    val newTimestamp = deletionTimestamp(retentionS)
+  override fun recalculateDeletionTimestamp(retentionSeconds: Long, numResources: Int) {
+    val newTimestamp = deletionTimestamp(retentionSeconds)
     log.info("Setting deletion time to $newTimestamp for $numResources resources in ${javaClass.simpleName}.")
 
     val markedResources = resourceRepository.getMarkedResources()

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandler.kt
@@ -73,6 +73,11 @@ interface ResourceTypeHandler<T : Resource> {
   fun evaluateCandidate(resourceId: String, resourceName: String, workConfiguration: WorkConfiguration): ResourceEvaluation
 
   /**
+   * Admin api to recalculate deletion timestamp for a number of resources
+   */
+  fun recalculateDeletionTimestamp(retentionS: Long, numResources: Int)
+
+  /**
    * FOR TESTING
    * Marks a single resource w/o checking if it should be marked.
    */

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandler.kt
@@ -73,9 +73,9 @@ interface ResourceTypeHandler<T : Resource> {
   fun evaluateCandidate(resourceId: String, resourceName: String, workConfiguration: WorkConfiguration): ResourceEvaluation
 
   /**
-   * Admin api to recalculate deletion timestamp for a number of resources
+   * Admin api to recalculate deletion timestamp for [numResources] to [retentionSeconds] from now
    */
-  fun recalculateDeletionTimestamp(retentionS: Long, numResources: Int)
+  fun recalculateDeletionTimestamp(retentionSeconds: Long, numResources: Int)
 
   /**
    * FOR TESTING

--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/AdminController.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/AdminController.kt
@@ -1,0 +1,31 @@
+package com.netflix.spinnaker.swabbie.controllers
+
+import com.netflix.spinnaker.swabbie.model.SwabbieNamespace
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/admin")
+class AdminController(
+    private val controllerUtils: ControllerUtils
+) {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  /**
+   * Recalculate deletion timestamp to [retentionS] seconds in the future for the
+   * oldest [numResources] that are marked
+   */
+  @RequestMapping(value = ["/resources/recalculate/{namespace}/"], method = [RequestMethod.PUT])
+  fun recalculate(
+      @PathVariable namespace: String,
+      @RequestParam(required = true) retentionSeconds: Long,
+      @RequestParam(required = true) numResources: Int
+  ) {
+    log.info("Recalculating deletion timestamp for oldest $numResources resources in $namespace. " +
+        "Setting to ${retentionSeconds}s from now.")
+    val workConfiguration = controllerUtils.findWorkConfiguration(SwabbieNamespace.namespaceParser(namespace))
+    val handler = controllerUtils.findHandler(workConfiguration)
+    handler.recalculateDeletionTimestamp(retentionSeconds, numResources)
+  }
+}

--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ControllerUtils.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ControllerUtils.kt
@@ -1,0 +1,28 @@
+package com.netflix.spinnaker.swabbie.controllers
+
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
+import com.netflix.spinnaker.swabbie.ResourceTypeHandler
+import com.netflix.spinnaker.swabbie.model.SwabbieNamespace
+import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import org.springframework.stereotype.Component
+
+@Component
+class ControllerUtils(
+  private val resourceTypeHandlers: List<ResourceTypeHandler<*>>,
+  private val workConfigurations: List<WorkConfiguration>
+) {
+  fun findWorkConfiguration(namespace: SwabbieNamespace): WorkConfiguration {
+    return workConfigurations.find { workConfiguration ->
+      workConfiguration.account.name == namespace.accountName
+          && workConfiguration.cloudProvider == namespace.cloudProvider
+          && workConfiguration.resourceType == namespace.resourceType
+          && workConfiguration.location == namespace.region
+    } ?: throw NotFoundException("No configuration found for $namespace")
+  }
+
+  fun findHandler(workConfiguration: WorkConfiguration): ResourceTypeHandler<*> {
+    return resourceTypeHandlers.find { handler ->
+      handler.handles(workConfiguration)
+    } ?: throw NotFoundException("No handlers for ${workConfiguration.namespace}")
+  }
+}

--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.swabbie.controllers
 
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
-import com.netflix.spinnaker.swabbie.*
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.events.OptOutResourceEvent
 import com.netflix.spinnaker.swabbie.model.*
@@ -34,8 +33,7 @@ class ResourceController(
   private val resourceStateRepository: ResourceStateRepository,
   private val resourceTrackingRepository: ResourceTrackingRepository,
   private val applicationEventPublisher: ApplicationEventPublisher,
-  private val workConfigurations: List<WorkConfiguration>,
-  private val resourceTypeHandlers: List<ResourceTypeHandler<*>>
+  private val controllerUtils: ControllerUtils
 ) {
 
   private val log = LoggerFactory.getLogger(javaClass)
@@ -149,19 +147,14 @@ class ResourceController(
     if (markedResource != null) {
       log.debug("Found resource ${markedResource.uniqueId()} to opt out.")
       resourceTrackingRepository.remove(markedResource)
-      workConfigurations.find {
-        it.namespace.equals(namespace, true)
-      }?.also { configuration ->
-        log.debug("Publishing opt out event for ${markedResource.uniqueId()}")
-        applicationEventPublisher.publishEvent(OptOutResourceEvent(markedResource, configuration))
-      }
-    } else {
-      log.debug("Did not find marked resource ${namespace}:${resourceId} to opt out. Opting out anyways.")
-      val workConfiguration = findWorkConfiguration(SwabbieNamespace.namespaceParser(namespace))
+      val workConfiguration = controllerUtils.findWorkConfiguration(SwabbieNamespace.namespaceParser(namespace))
 
-      val handler = resourceTypeHandlers.find { handler ->
-        handler.handles(workConfiguration)
-      } ?: throw NotFoundException("No handlers for $namespace")
+      log.debug("Publishing opt out event for ${markedResource.uniqueId()}")
+      applicationEventPublisher.publishEvent(OptOutResourceEvent(markedResource, workConfiguration))
+    } else {
+      log.debug("Did not find marked resource $namespace:$resourceId to opt out. Opting out anyways.")
+      val workConfiguration = controllerUtils.findWorkConfiguration(SwabbieNamespace.namespaceParser(namespace))
+      val handler = controllerUtils.findHandler(workConfiguration)
 
       handler.optOut(resourceId, workConfiguration)
     }
@@ -178,40 +171,10 @@ class ResourceController(
     @PathVariable namespace: String,
     @PathVariable resourceId: String
   ): ResourceEvaluation {
-    val workConfiguration = findWorkConfiguration(SwabbieNamespace.namespaceParser(namespace))
+    val workConfiguration = controllerUtils.findWorkConfiguration(SwabbieNamespace.namespaceParser(namespace))
     val newWorkConfiguration = workConfiguration.copy(dryRun = true)
-
-    val handler = resourceTypeHandlers.find { handler ->
-      handler.handles(newWorkConfiguration)
-    } ?: throw NotFoundException("No handlers for $namespace")
+    val handler = controllerUtils.findHandler(newWorkConfiguration)
 
     return handler.evaluateCandidate(resourceId, resourceId, newWorkConfiguration)
-  }
-
-  private fun findWorkConfiguration(namespace: SwabbieNamespace): WorkConfiguration {
-    return workConfigurations.find { workConfiguration ->
-      workConfiguration.account.name == namespace.accountName
-        && workConfiguration.cloudProvider == namespace.cloudProvider
-        && workConfiguration.resourceType == namespace.resourceType
-        && workConfiguration.location == namespace.region
-    } ?: throw NotFoundException("No configuration found for $namespace")
-  }
-
-  /**
-   * Recalculate deletion timestamp to @retentionS seconds in the future for the
-   * oldest @numResources that are marked
-   */
-  @RequestMapping(value = ["/recalculate/{namespace}/"], method = [RequestMethod.PUT])
-  fun recalculate(
-      @PathVariable namespace: String,
-      @RequestParam(required = true) retentionS: Long,
-      @RequestParam(required = false, defaultValue = "100") numResources: Int
-  ) {
-    log.info("Recalculating deletion timestamp for oldest $numResources resources in $namespace. Setting to ${retentionS}s from now.")
-    val workConfiguration = findWorkConfiguration(SwabbieNamespace.namespaceParser(namespace))
-    val handler = resourceTypeHandlers.find { handler ->
-      handler.handles(workConfiguration)
-    } ?: throw NotFoundException("No handlers for $namespace")
-    handler.recalculateDeletionTimestamp(retentionS, numResources)
   }
 }


### PR DESCRIPTION
We may want to update the deletion time of a bunch of resources, like if we want to speed up or slow down deletion of resources.

This admin endpoint lets you update the deletion time for the oldest `numResources` resources to a value of `retentionS` seconds from now. It operates in a single namespace.