### PR TITLE
feat(notify): notifications not always required

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
@@ -61,8 +61,25 @@ class CloudProviderConfiguration {
   }
 }
 
+/**
+ * Notifications have both an [enabled] and a [required] configuration.
+ *  [enabled] is whether or not the notification agent runs for this configuration.
+ *  [required] is whether or not a resource must be notified before it can be deleted.
+ *
+ * If [enabled] is true and [required] is true then notifications will be sent to the owner.
+ *
+ * If [enabled] is true and [required] is false a resource will be marked as 'notification not needed'
+ *  and will be able to be deleted. No notifications will be sent.
+ *
+ * If [enabled] is false then the notification agent will not run for this configuration
+ *  and resources of this type won't be able to be deleted.
+ *
+ *  TODO EB: Remove the hard dependency on notifications for all resources.
+ *   Instead, make this configurable in a logical and flexible way.
+ */
 open class NotificationConfiguration(
   var enabled: Boolean = false,
+  var required: Boolean = true,
   var types: MutableList<String> = mutableListOf("Email"),
   var optOutBaseUrl: String = "",
   var itemsPerMessage: Int = 10,

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/notifications/Notifier.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/notifications/Notifier.kt
@@ -21,7 +21,8 @@ interface Notifier {
 
   enum class NotificationType {
     SLACK,
-    EMAIL
+    EMAIL,
+    NONE
   }
 
   enum class NotificationSeverity {


### PR DESCRIPTION
Some resources need to be cleaned too often to notify users every time we delete something. Janitor monkey did not notify for image clean up, so this PR adds that functionality into swabbie.

The default behavior is the same. However, if you set 
``` 
notifications:
  enabled: true
  required: false
```
the notification agent will run but no notifications will be sent. 

This behavior is a little bit convoluted - a cleaner solution would be to have deletion not depend on notifying for all resources. However, that would be a large change to the assumptions of Swabbie (something must be notified before it was deleted. This PR keeps the same assumptions and adds support for not notifying with minimal changes.

There are also some indentation changes because I ran the auto-formatter.