### PR TITLE
fix(mark): only unmark a config number at once, add totalMarkCount metric

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
@@ -35,6 +35,7 @@ open class SwabbieProperties {
   var testing: Testing = Testing()
   var minImagesUsedByLC = 500
   var minImagesUsedByInst = 500
+  var maxUnmarkedPerCycle = 250
 }
 
 class Testing {

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/MetricsSupport.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/MetricsSupport.kt
@@ -50,6 +50,7 @@ open class MetricsSupport(
   protected val notifyCountId: Id = registry.createId("swabbie.resources.notifyCount")
   protected val optOutCountId: Id = registry.createId("swabbie.resources.optOutCount")
   protected val orcaTaskFailureId: Id = registry.createId("swabbie.resources.orcaTaskFailureCount")
+  protected val totalMarkedId: Id = registry.createId("swabbie.resources.totalMarked")
 
   protected val failedAgentId: Id = registry.createId("swabbie.agents.failed")
   protected val failedDuringSchedule: Id = registry.createId("swabbie.scheduled.failed")
@@ -59,7 +60,8 @@ open class MetricsSupport(
                                   workConfiguration: WorkConfiguration,
                                   violationCounter: AtomicInteger,
                                   candidateCounter: AtomicInteger,
-                                  totalResourcesVisitedCounter: AtomicInteger) {
+                                  totalResourcesVisitedCounter: AtomicInteger,
+                                  totalMarkedCount: Long) {
     markDurationTimer.stop(markerTimerId)
     registry.gauge(
       candidatesCountId.withTags(
@@ -88,6 +90,8 @@ open class MetricsSupport(
         "configuration", workConfiguration.namespace,
         "resourceTypeHandler", javaClass.simpleName
       )).set(totalResourcesVisitedCounter.toDouble())
+
+    registry.gauge(totalMarkedId).set(totalMarkedCount.toDouble())
   }
 
   protected fun recordFailureForAction(action: Action, workConfiguration: WorkConfiguration, e: Exception) {


### PR DESCRIPTION
Periodically I'll see a ton of resources unmarked for no reason. When I look in detail at them, I don't see that they were used. Just that they suddenly "don't qualify to be deleted" anymore. My working theory is that sometimes we get back a subset of data from edda or from redis, and that causes us to wipe anything we don't know about.

This PR adds a configurable max number of resources to unmark at once so that if this happens occasionally we won't unmark all our resources. 

It also adds some logging and metrics around the number marked so that I can further debug.