### PR TITLE
feat(snapshots): snapshot handler to first pass

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/EddaService.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/EddaService.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.swabbie.aws.instances.AmazonInstance
 import com.netflix.spinnaker.swabbie.aws.launchconfigurations.AmazonLaunchConfiguration
 import com.netflix.spinnaker.swabbie.aws.loadbalancers.AmazonElasticLoadBalancer
 import com.netflix.spinnaker.swabbie.aws.securitygroups.AmazonSecurityGroup
+import com.netflix.spinnaker.swabbie.aws.snapshots.AmazonSnapshot
 import retrofit.http.GET
 import retrofit.http.Path
 
@@ -52,6 +53,12 @@ interface EddaService {
 
   @GET("/api/v2/aws/images/{imageId}")
   fun getImage(@Path("imageId") imageId: String): AmazonImage
+
+  @GET("/api/v2/aws/snapshots;_expand")
+  fun getSnapshots(): List<AmazonSnapshot>
+
+  @GET("/api/v2/aws/snapshots/{snapshotId}")
+  fun getSnapshot(@Path("snapshotId") snapshotId: String): AmazonSnapshot
 
   @GET("/api/v2/view/instances/{instanceId}")
   fun getInstance(@Path("instanceId") instanceId: String): AmazonInstance

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImage.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImage.kt
@@ -36,7 +36,6 @@ data class AmazonImage(
   private val creationDate: String?
 ) : AmazonResource(creationDate)
 
-@JsonTypeName("blockDevice")
 data class AmazonBlockDevice(
   val ebs: EbsBlockDevice?,
   val noDevice: String?,
@@ -44,7 +43,6 @@ data class AmazonBlockDevice(
   val virtualName: String?
 )
 
-@JsonTypeName("ebs")
 data class AmazonEbs(
   val snapshotId: String?,
   val virtualName: String?

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImage.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImage.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.swabbie.aws.images
 
+import com.amazonaws.services.ec2.model.EbsBlockDevice
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.netflix.spinnaker.swabbie.aws.model.AmazonResource
 import com.netflix.spinnaker.swabbie.model.AWS
@@ -27,9 +28,24 @@ data class AmazonImage(
   val ownerId: String?,
   val description: String?,
   val state: String,
+  val blockDeviceMappings: List<AmazonBlockDevice>?,
   override val resourceId: String = imageId,
   override val resourceType: String = IMAGE,
   override val cloudProvider: String = AWS,
   override val name: String?,
   private val creationDate: String?
 ) : AmazonResource(creationDate)
+
+@JsonTypeName("blockDevice")
+data class AmazonBlockDevice(
+  val ebs: EbsBlockDevice?,
+  val noDevice: String?,
+  val deviceName: String?,
+  val virtualName: String?
+)
+
+@JsonTypeName("ebs")
+data class AmazonEbs(
+  val snapshotId: String?,
+  val virtualName: String?
+)

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -61,6 +61,7 @@ class AmazonImageHandler(
   private val applicationUtils: ApplicationUtils,
   private val taskTrackingRepository: TaskTrackingRepository,
   private val resourceUseTrackingRepository: ResourceUseTrackingRepository,
+  private val usedSnapshotRepository: UsedSnapshotRepository,
   private val swabbieProperties: SwabbieProperties
 ) : AbstractResourceTypeHandler<AmazonImage>(
   registry,
@@ -155,9 +156,17 @@ class AmazonImageHandler(
 
     log.debug("checking references for {} resources. Parameters: {}", images.size, params)
 
-    images.forEach {
-      if (it.name == null || it.description == null) {
-        it.set(NAIVE_EXCLUSION, true) // exclude these with exclusions
+    images.forEach { image ->
+      if (image.name == null || image.description == null) {
+        image.set(NAIVE_EXCLUSION, true) // exclude these with exclusions
+      }
+
+      if (image.blockDeviceMappings != null){
+        image.blockDeviceMappings.forEach { blockDevice ->
+          if (blockDevice.ebs != null && blockDevice.ebs.snapshotId != null) {
+            usedSnapshotRepository.recordUse(blockDevice.ebs.snapshotId, "aws:${params.region}:${params.account}") //todo eb: is this value needed?
+          }
+        }
       }
     }
 

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -61,7 +61,7 @@ class AmazonImageHandler(
   private val applicationUtils: ApplicationUtils,
   private val taskTrackingRepository: TaskTrackingRepository,
   private val resourceUseTrackingRepository: ResourceUseTrackingRepository,
-  private val usedSnapshotRepository: UsedSnapshotRepository,
+  private val usedResourceRepository: UsedResourceRepository,
   private val swabbieProperties: SwabbieProperties
 ) : AbstractResourceTypeHandler<AmazonImage>(
   registry,
@@ -164,7 +164,7 @@ class AmazonImageHandler(
       if (image.blockDeviceMappings != null){
         image.blockDeviceMappings.forEach { blockDevice ->
           if (blockDevice.ebs != null && blockDevice.ebs.snapshotId != null) {
-            usedSnapshotRepository.recordUse(blockDevice.ebs.snapshotId, "aws:${params.region}:${params.account}") //todo eb: is this value needed?
+            usedResourceRepository.recordUse(SNAPSHOT, blockDevice.ebs.snapshotId, "aws:${params.region}:${params.account}")
           }
         }
       }

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshot.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshot.kt
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.aws.snapshots
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.netflix.spinnaker.swabbie.Dates
+import com.netflix.spinnaker.swabbie.aws.model.AmazonResource
+import com.netflix.spinnaker.swabbie.model.AWS
+import com.netflix.spinnaker.swabbie.model.SNAPSHOT
+
+@JsonTypeName("amazonSnapshot")
+data class AmazonSnapshot(
+  val volumeId: String,
+  val state: String,
+  val progress: String,
+  val volumeSize: Int,
+  val startTime: Long,
+  val description: String?,
+  val snapshotId: String,
+  val ownerId: String,
+  val encrypted: Boolean,
+  val ownerAlias: String?,
+  val stateMessage: String?,
+  override val resourceId: String = snapshotId,
+  override val resourceType: String = SNAPSHOT,
+  override val cloudProvider: String = AWS,
+  override val name: String = snapshotId,
+  private val creationDate: String? =  Dates.toCreationDate(startTime)
+) : AmazonResource(creationDate)

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandler.kt
@@ -1,0 +1,151 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.aws.snapshots
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.config.SwabbieProperties
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.swabbie.*
+import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
+import com.netflix.spinnaker.swabbie.model.*
+import com.netflix.spinnaker.swabbie.notifications.Notifier
+import com.netflix.spinnaker.swabbie.orca.OrcaService
+import com.netflix.spinnaker.swabbie.repository.*
+import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.util.*
+
+@Component
+class AmazonSnapshotHandler(
+  registry: Registry,
+  clock: Clock,
+  notifiers: List<Notifier>,
+  resourceTrackingRepository: ResourceTrackingRepository,
+  resourceStateRepository: ResourceStateRepository,
+  resourceOwnerResolver: ResourceOwnerResolver<AmazonSnapshot>,
+  exclusionPolicies: List<ResourceExclusionPolicy>,
+  applicationEventPublisher: ApplicationEventPublisher,
+  lockingService: Optional<LockingService>,
+  retrySupport: RetrySupport,
+  dynamicConfigService: DynamicConfigService,
+  private val rules: List<Rule<AmazonSnapshot>>,
+  private val snapshotProvider: ResourceProvider<AmazonSnapshot>,
+  private val orcaService: OrcaService,
+  private val applicationUtils: ApplicationUtils,
+  private val taskTrackingRepository: TaskTrackingRepository,
+  private val resourceUseTrackingRepository: ResourceUseTrackingRepository,
+  private val usedSnapshotRepository: UsedSnapshotRepository,
+  private val swabbieProperties: SwabbieProperties
+) : AbstractResourceTypeHandler<AmazonSnapshot>(
+  registry,
+  clock,
+  rules,
+  resourceTrackingRepository,
+  resourceStateRepository,
+  exclusionPolicies,
+  resourceOwnerResolver,
+  notifiers,
+  applicationEventPublisher,
+  lockingService,
+  retrySupport,
+  resourceUseTrackingRepository,
+  swabbieProperties,
+  dynamicConfigService
+) {
+  override fun deleteResources(markedResources: List<MarkedResource>, workConfiguration: WorkConfiguration) {
+    TODO("not implemented")
+  }
+
+  override fun handles(workConfiguration: WorkConfiguration): Boolean =
+    workConfiguration.resourceType == SNAPSHOT && workConfiguration.cloudProvider == AWS && !rules.isEmpty()
+
+  override fun getCandidate(resourceId: String, resourceName: String, workConfiguration: WorkConfiguration): AmazonSnapshot? {
+    val params = Parameters(
+      id = resourceId,
+      account = workConfiguration.account.accountId!!,
+      region = workConfiguration.location,
+      environment = workConfiguration.account.environment
+    )
+
+    return snapshotProvider.getOne(params)
+  }
+
+  override fun getCandidates(workConfiguration: WorkConfiguration): List<AmazonSnapshot>? {
+    val params = Parameters(
+      account = workConfiguration.account.accountId!!,
+      region = workConfiguration.location,
+      environment = workConfiguration.account.environment
+    )
+
+    return snapshotProvider.getAll(params).also { snapshots ->
+      log.info("Got {} snapshots.", snapshots?.size)
+    }
+  }
+
+  override fun preProcessCandidates(
+    candidates: List<AmazonSnapshot>,
+    workConfiguration: WorkConfiguration
+  ): List<AmazonSnapshot> {
+    checkIfImagesExist(
+      candidates = candidates,
+      params = Parameters(
+        account = workConfiguration.account.accountId!!,
+        region = workConfiguration.location,
+        environment = workConfiguration.account.environment
+      ))
+    return candidates
+  }
+
+  private fun checkIfImagesExist(candidates: List<AmazonSnapshot>, params: Parameters) {
+    log.info("Checking for existing images for {} snapshots. Params: {} ", candidates.size, params)
+    candidates.forEach { snapshot ->
+      if (snapshot.description == null) {
+        snapshot.set(SNAPSHOT_NOT_FROM_BAKE, true)
+        return
+      }
+
+      if (descriptionIsFromAutoBake(snapshot.description)) {
+          // if description contains these keys then it's most likely an auto-captured snapshot.
+        if (usedSnapshotRepository.isUsed(snapshot.snapshotId, "aws:${params.region}:${params.account}")) {
+          snapshot.set(IMAGE_EXISTS, true)
+        }
+      } else {
+        snapshot.set(SNAPSHOT_NOT_FROM_BAKE, true)
+      }
+    }
+  }
+
+  fun descriptionIsFromAutoBake(description: String): Boolean {
+    //description=name=nflx-sirt-forensics, arch=x86_64, ancestor_name=bionic-classicbase-unstable-x86_64-201902272237-ebs, ancestor_id=ami-067321616378baefc, ancestor_version=nflx-base-5.347.2-h1144.4aace97~unstable
+    val pairs = description.replace(" ","").split(",")
+    val parsedDescr = mutableMapOf<String,String>()
+    pairs.forEach { pair ->
+      val split = pair.split("=")
+      if (split.size == 2) {
+        parsedDescr[split[0]] = split[1]
+      }
+    }
+
+    return parsedDescr.containsKey("name") && parsedDescr.containsKey("ancestor_name") &&
+      parsedDescr.containsKey("ancestor_id") && parsedDescr.containsKey("ancestor_version")
+  }
+}

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/SnapshotRules.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/SnapshotRules.kt
@@ -1,0 +1,54 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.aws.snapshots
+
+import com.netflix.spinnaker.swabbie.model.Result
+import com.netflix.spinnaker.swabbie.model.Rule
+import com.netflix.spinnaker.swabbie.model.Summary
+import org.springframework.stereotype.Component
+
+/**
+ * Snapshots with a specific naming pattern are created automatically by the bakery when
+ *  the image is created. Once an image is deleted we can safely clean up the snapshot.
+ */
+@Component
+class OrphanedSnapshotRule : Rule<AmazonSnapshot> {
+  override fun apply(resource: AmazonSnapshot): Result {
+    if (resource.matchesAnyRule(
+        IMAGE_EXISTS,
+        SNAPSHOT_NOT_FROM_BAKE
+      )){
+      return Result(null)
+    }
+
+    return Result(
+      Summary(
+        description = "This snapshot was auto-generated at bake time and the image no longer exists",
+        ruleName = name()
+      )
+    )
+  }
+
+  private fun AmazonSnapshot.matchesAnyRule(vararg ruleName: String): Boolean {
+    return ruleName.any { details.containsKey(it) && details[it] as Boolean }
+  }
+}
+
+const val IMAGE_EXISTS = "imageExists"
+const val SNAPSHOT_NOT_FROM_BAKE = "snapshotNotFromBake"

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/SnapshotRules.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/SnapshotRules.kt
@@ -31,8 +31,7 @@ import org.springframework.stereotype.Component
 class OrphanedSnapshotRule : Rule<AmazonSnapshot> {
   override fun apply(resource: AmazonSnapshot): Result {
     if (resource.matchesAnyRule(
-        IMAGE_EXISTS,
-        SNAPSHOT_NOT_FROM_BAKE
+        IMAGE_EXISTS
       )){
       return Result(null)
     }
@@ -51,4 +50,3 @@ class OrphanedSnapshotRule : Rule<AmazonSnapshot> {
 }
 
 const val IMAGE_EXISTS = "imageExists"
-const val SNAPSHOT_NOT_FROM_BAKE = "snapshotNotFromBake"

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
@@ -51,7 +51,7 @@ object AmazonImageHandlerTest {
   private val accountProvider = mock<AccountProvider>()
   private val resourceRepository = mock<ResourceTrackingRepository>()
   private val resourceStateRepository = mock<ResourceStateRepository>()
-  private val usedSnapshotRepository = mock<UsedSnapshotRepository>()
+  private val usedSnapshotRepository = mock<UsedResourceRepository>()
   private val resourceOwnerResolver = mock<ResourceOwnerResolver<AmazonImage>>()
   private val clock = Clock.fixed(Instant.parse("2018-05-24T12:34:56Z"), ZoneOffset.UTC)
   private val applicationEventPublisher = mock<ApplicationEventPublisher>()
@@ -96,7 +96,7 @@ object AmazonImageHandlerTest {
     imagesUsedByinstancesCache = imagesUsedByinstancesCache,
     applicationUtils = applicationUtils,
     dynamicConfigService = dynamicConfigService,
-    usedSnapshotRepository = usedSnapshotRepository
+    usedResourceRepository = usedSnapshotRepository
   )
 
   @BeforeEach

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
@@ -19,12 +19,7 @@ package com.netflix.spinnaker.swabbie.aws.images
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.should.shouldMatch
 import com.netflix.spectator.api.NoopRegistry
-import com.netflix.spinnaker.config.Attribute
-import com.netflix.spinnaker.config.CloudProviderConfiguration
-import com.netflix.spinnaker.config.Exclusion
-import com.netflix.spinnaker.config.ExclusionType
-import com.netflix.spinnaker.config.ResourceTypeConfiguration
-import com.netflix.spinnaker.config.SwabbieProperties
+import com.netflix.spinnaker.config.*
 import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.swabbie.*
@@ -49,13 +44,14 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.validateMockitoUsage
 import org.springframework.context.ApplicationEventPublisher
 import java.time.*
-import java.util.Optional
+import java.util.*
 
 object AmazonImageHandlerTest {
   private val front50ApplicationCache = mock<InMemoryCache<Application>>()
   private val accountProvider = mock<AccountProvider>()
   private val resourceRepository = mock<ResourceTrackingRepository>()
   private val resourceStateRepository = mock<ResourceStateRepository>()
+  private val usedSnapshotRepository = mock<UsedSnapshotRepository>()
   private val resourceOwnerResolver = mock<ResourceOwnerResolver<AmazonImage>>()
   private val clock = Clock.fixed(Instant.parse("2018-05-24T12:34:56Z"), ZoneOffset.UTC)
   private val applicationEventPublisher = mock<ApplicationEventPublisher>()
@@ -99,7 +95,8 @@ object AmazonImageHandlerTest {
     launchConfigurationCache = launchConfigurationCache,
     imagesUsedByinstancesCache = imagesUsedByinstancesCache,
     applicationUtils = applicationUtils,
-    dynamicConfigService = dynamicConfigService
+    dynamicConfigService = dynamicConfigService,
+    usedSnapshotRepository = usedSnapshotRepository
   )
 
   @BeforeEach
@@ -145,7 +142,8 @@ object AmazonImageHandlerTest {
         resourceType = IMAGE,
         cloudProvider = AWS,
         name = "123-xenial-hvm-sriov-ebs",
-        creationDate = LocalDateTime.now().minusDays(3).toString()
+        creationDate = LocalDateTime.now().minusDays(3).toString(),
+        blockDeviceMappings = emptyList()
       ),
       AmazonImage(
         imageId = "ami-132",
@@ -156,7 +154,8 @@ object AmazonImageHandlerTest {
         resourceType = IMAGE,
         cloudProvider = AWS,
         name = "132-xenial-hvm-sriov-ebs",
-        creationDate = LocalDateTime.now().minusDays(3).toString()
+        creationDate = LocalDateTime.now().minusDays(3).toString(),
+        blockDeviceMappings = emptyList()
       )
     )
 
@@ -345,7 +344,8 @@ object AmazonImageHandlerTest {
         resourceType = IMAGE,
         cloudProvider = AWS,
         name = "123-xenial-hvm-sriov-ebs",
-        creationDate = LocalDateTime.now().minusDays(3).toString()
+        creationDate = LocalDateTime.now().minusDays(3).toString(),
+        blockDeviceMappings = emptyList()
       ),
       AmazonImage(
         imageId = "ami-132",
@@ -356,7 +356,8 @@ object AmazonImageHandlerTest {
         resourceType = IMAGE,
         cloudProvider = AWS,
         name = "132-xenial-hvm-sriov-ebs",
-        creationDate = LocalDateTime.now().minusDays(3).toString()
+        creationDate = LocalDateTime.now().minusDays(3).toString(),
+        blockDeviceMappings = emptyList()
       )
     )
 
@@ -389,7 +390,8 @@ object AmazonImageHandlerTest {
       resourceType = IMAGE,
       cloudProvider = AWS,
       name = "123-xenial-hvm-sriov-ebs",
-      creationDate = LocalDateTime.now().minusDays(3).toString()
+      creationDate = LocalDateTime.now().minusDays(3).toString(),
+      blockDeviceMappings = emptyList()
     )
 
     whenever(resourceRepository.getMarkedResourcesToDelete()) doReturn

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandlerTest.kt
@@ -1,0 +1,327 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.aws.snapshots
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.should.shouldMatch
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.config.*
+import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.swabbie.*
+import com.netflix.spinnaker.swabbie.aws.images.AmazonImage
+import com.netflix.spinnaker.swabbie.events.MarkResourceEvent
+import com.netflix.spinnaker.swabbie.exclusions.AccountExclusionPolicy
+import com.netflix.spinnaker.swabbie.exclusions.AllowListExclusionPolicy
+import com.netflix.spinnaker.swabbie.exclusions.LiteralExclusionPolicy
+import com.netflix.spinnaker.swabbie.model.Application
+import com.netflix.spinnaker.swabbie.model.Region
+import com.netflix.spinnaker.swabbie.model.SpinnakerAccount
+import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import com.netflix.spinnaker.swabbie.orca.OrcaService
+import com.netflix.spinnaker.swabbie.repository.*
+import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
+import com.nhaarman.mockito_kotlin.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.*
+
+object AmazonSnapshotHandlerTest {
+
+  private val log: Logger = LoggerFactory.getLogger(this.javaClass)
+  val objectMapper = ObjectMapper().registerKotlinModule().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+  @Test
+  fun `data convert`() {
+    val raw = "{\"volumeId\":\"vol-160d2afc\",\"state\":\"completed\",\"progress\":\"100%\",\"volumeSize\":10,\"startTime\":1438719239000,\"tags\":[{\"class\":\"com.amazonaws.services.ec2.model.Tag\",\"value\":\"http://cpe.builds.test.netflix.net/\",\"build_host\":\"http://cpe.builds.test.netflix.net/\",\"key\":\"build_host\"},{\"class\":\"com.amazonaws.services.ec2.model.Tag\",\"value\":\"builds\",\"creator\":\"builds\",\"key\":\"creator\"},{\"class\":\"com.amazonaws.services.ec2.model.Tag\",\"value\":\"l10nservicegeneral-1.0-h6.4a59761/DSC-LPE-l10nservicegeneral-test-build/6\",\"appversion\":\"l10nservicegeneral-1.0-h6.4a59761/DSC-LPE-l10nservicegeneral-test-build/6\",\"key\":\"appversion\"},{\"class\":\"com.amazonaws.services.ec2.model.Tag\",\"value\":\"nflx-base-1.491-h442.9192f05\",\"base_ami_version\":\"nflx-base-1.491-h442.9192f05\",\"key\":\"base_ami_version\"}],\"description\":\"name=l10nservicegeneral, arch=x86_64, ancestor_name=trustybase-x86_64-201507101816-ebs, ancestor_id=ami-5b31f930, ancestor_version=nflx-base-1.491-h442.9192f05\",\"dataEncryptionKeyId\":null,\"kmsKeyId\":null,\"snapshotId\":\"snap-721b6e38\",\"ownerId\":\"179727101194\",\"encrypted\":false,\"class\":\"com.amazonaws.services.ec2.model.Snapshot\",\"ownerAlias\":null,\"stateMessage\":null}"
+    val raw2 = "{\"volumeId\":\"vol-ffffffff\",\"state\":\"completed\",\"progress\":\"100%\",\"volumeSize\":3,\"startTime\":1542397011400,\"tags\":[],\"description\":\"Created by AWS-VMImport service for import-snap-fhcp6i74\",\"dataEncryptionKeyId\":null,\"kmsKeyId\":null,\"snapshotId\":\"snap-0333155d642f6fccb\",\"ownerId\":\"085178109370\",\"encrypted\":false,\"class\":\"com.amazonaws.services.ec2.model.Snapshot\",\"ownerAlias\":null,\"stateMessage\":null}"
+    val snapshot: AmazonSnapshot = objectMapper.readValue(raw)
+    val snapshot2: AmazonSnapshot = objectMapper.readValue(raw2)
+
+    assert(snapshot.snapshotId == "snap-721b6e38")
+    assert(snapshot2.snapshotId == "snap-0333155d642f6fccb")
+  }
+
+  @Test
+  fun `image con`() {
+    val raw = "{\"description\":\"name=clouddriver, arch=x86_64, ancestor_name=xenialbase-x86_64-201901230035-ebs, ancestor_id=ami-0fec712ac298b612f, ancestor_version=nflx-base-5.328.0-h1108.7154fd2\",\"kernelId\":null,\"class\":\"com.amazonaws.services.ec2.model.Image\",\"name\":\"clouddriver-1.1623.0-h1739.a209fcb-x86_64-20190130210356-xenial-hvm-sriov-ebs\",\"stateReason\":null,\"virtualizationType\":\"hvm\",\"blockDeviceMappings\":[{\"virtualName\":null,\"ebs\":{\"snapshotId\":\"snap-0fbf910c6568eaa40\",\"encrypted\":false,\"volumeSize\":10,\"deleteOnTermination\":true,\"kmsKeyId\":null,\"class\":\"com.amazonaws.services.ec2.model.EbsBlockDevice\",\"iops\":null,\"volumeType\":\"standard\"},\"class\":\"com.amazonaws.services.ec2.model.BlockDeviceMapping\",\"noDevice\":null,\"deviceName\":\"/dev/sda1\"},{\"virtualName\":\"ephemeral0\",\"ebs\":null,\"class\":\"com.amazonaws.services.ec2.model.BlockDeviceMapping\",\"noDevice\":null,\"deviceName\":\"/dev/sdb\"},{\"virtualName\":\"ephemeral1\",\"ebs\":null,\"class\":\"com.amazonaws.services.ec2.model.BlockDeviceMapping\",\"noDevice\":null,\"deviceName\":\"/dev/sdc\"},{\"virtualName\":\"ephemeral2\",\"ebs\":null,\"class\":\"com.amazonaws.services.ec2.model.BlockDeviceMapping\",\"noDevice\":null,\"deviceName\":\"/dev/sdd\"},{\"virtualName\":\"ephemeral3\",\"ebs\":null,\"class\":\"com.amazonaws.services.ec2.model.BlockDeviceMapping\",\"noDevice\":null,\"deviceName\":\"/dev/sde\"}],\"imageLocation\":\"179727101194/clouddriver-1.1623.0-h1739.a209fcb-x86_64-20190130210356-xenial-hvm-sriov-ebs\",\"public\":false,\"rootDeviceName\":\"/dev/sda1\",\"hypervisor\":\"xen\",\"sriovNetSupport\":\"simple\",\"rootDeviceType\":\"ebs\",\"platform\":null,\"imageOwnerAlias\":null,\"ownerId\":\"179727101194\",\"state\":\"available\",\"imageId\":\"ami-08366161198075aff\",\"imageType\":\"machine\",\"ramdiskId\":null,\"enaSupport\":true,\"productCodes\":[],\"creationDate\":\"2019-01-30T21:08:46.000Z\",\"architecture\":\"x86_64\"}"
+    val image: AmazonImage = objectMapper.readValue(raw)
+    assert( image.imageId == "ami-08366161198075aff")
+  }
+
+  private val front50ApplicationCache = mock<InMemoryCache<Application>>()
+  private val accountProvider = mock<AccountProvider>()
+  private val resourceRepository = mock<ResourceTrackingRepository>()
+  private val resourceStateRepository = mock<ResourceStateRepository>()
+  private val usedSnapshotRepository = mock<UsedSnapshotRepository>()
+  private val resourceOwnerResolver = mock<ResourceOwnerResolver<AmazonSnapshot>>()
+  private val clock = Clock.fixed(Instant.parse("2018-05-24T12:34:56Z"), ZoneOffset.UTC)
+  private val applicationEventPublisher = mock<ApplicationEventPublisher>()
+  private val lockingService = Optional.empty<LockingService>()
+  private val orcaService = mock<OrcaService>()
+  private val snapshotProvider = mock<ResourceProvider<AmazonSnapshot>>()
+  private val taskTrackingRepository = mock<TaskTrackingRepository>()
+  private val resourceUseTrackingRepository = mock<ResourceUseTrackingRepository>()
+  private val swabbieProperties = SwabbieProperties().apply {}
+  private val applicationUtils = ApplicationUtils(emptyList())
+  private val dynamicConfigService = mock<DynamicConfigService>()
+
+  private val subject = AmazonSnapshotHandler(
+    clock = clock,
+    registry = NoopRegistry(),
+    notifiers = listOf(mock()),
+    resourceTrackingRepository = resourceRepository,
+    resourceStateRepository = resourceStateRepository,
+    exclusionPolicies = listOf(
+      LiteralExclusionPolicy(),
+      AllowListExclusionPolicy(front50ApplicationCache, accountProvider)
+    ),
+    resourceOwnerResolver = resourceOwnerResolver,
+    applicationEventPublisher = applicationEventPublisher,
+    lockingService = lockingService,
+    retrySupport = RetrySupport(),
+    dynamicConfigService = dynamicConfigService,
+    rules = listOf(OrphanedSnapshotRule()),
+    snapshotProvider = snapshotProvider,
+    orcaService = orcaService,
+    applicationUtils = applicationUtils,
+    taskTrackingRepository = taskTrackingRepository,
+    resourceUseTrackingRepository = resourceUseTrackingRepository,
+    usedSnapshotRepository = usedSnapshotRepository,
+    swabbieProperties = swabbieProperties
+  )
+
+  @Test
+  fun `description matching works`() {
+    val d = "Created by AWS-VMImport service for import-snap-fh3h9fjz, snapshotId=snap-0c320e46155147100"
+    val d2 = "Copied for DestinationAmi ami-abc5d1bc from SourceAmi ami-51505e46 for SourceSnapshot snap-0ea59b6dfbba3cf48. Task created on 1,482,344,892,652."
+    val d3 = "snapshot of image.vmdk"
+    assert(!subject.descriptionIsFromAutoBake(d))
+    assert(!subject.descriptionIsFromAutoBake(d2))
+    assert(!subject.descriptionIsFromAutoBake(d3))
+
+    val d4 = "name=orca, arch=x86_64, ancestor_name=xenialbase-x86_64-201902202219-ebs, ancestor_id=ami-0fea682be4d892b0a, ancestor_version=nflx-base-5.344.0-h1137.cc92ef3"
+    assert(subject.descriptionIsFromAutoBake(d4))
+  }
+
+  @BeforeEach
+  fun setup() {
+    whenever(accountProvider.getAccounts()) doReturn
+      setOf(
+        SpinnakerAccount(
+          name = "test",
+          accountId = "1234",
+          type = "aws",
+          edda = "http://edda",
+          regions = listOf(Region(name = "us-east-1")),
+          eddaEnabled = false,
+          environment = "test"
+        ),
+        SpinnakerAccount(
+          name = "prod",
+          accountId = "4321",
+          type = "aws",
+          edda = "http://edda",
+          regions = listOf(Region(name = "us-east-1")),
+          eddaEnabled = false,
+          environment = "prod"
+        )
+      )
+
+    val params = Parameters(account = "1234", region = "us-east-1", environment = "test")
+    whenever(snapshotProvider.getAll(params)) doReturn listOf(
+      AmazonSnapshot(
+        volumeId = "vol-000",
+        state = "completed",
+        progress = "100%",
+        startTime = 1519943308000,
+        volumeSize = 10,
+        description = "name=swabbie, arch=x86_64, ancestor_name=xb-ebs, ancestor_id=ami-0000, ancestor_version=nflx-base-5",
+        snapshotId = "snap-000",
+        ownerId = "1234",
+        encrypted = false,
+        ownerAlias = null,
+        stateMessage = null
+      ),
+      AmazonSnapshot(
+        volumeId = "vol-111",
+        state = "completed",
+        progress = "100%",
+        startTime = 1519943307000,
+        volumeSize = 10,
+        description = "name=swabbie, arch=x86_64, ancestor_name=xb-ebs, ancestor_id=ami-0000, ancestor_version=nflx-base-4",
+        snapshotId = "snap-1111",
+        ownerId = "1234",
+        encrypted = false,
+        ownerAlias = null,
+        stateMessage = null
+      )
+    )
+  }
+
+  @AfterEach
+  fun cleanup() {
+    Mockito.validateMockitoUsage()
+    reset(
+      resourceRepository,
+      snapshotProvider,
+      accountProvider,
+      applicationEventPublisher,
+      resourceOwnerResolver,
+      taskTrackingRepository
+    )
+  }
+
+  @Test
+  fun `should handle snapshots`() {
+    Assertions.assertTrue(subject.handles(getWorkConfiguration()))
+  }
+
+  @Test
+  fun `should find snapshot cleanup candidates`() {
+    subject.getCandidates(getWorkConfiguration()).let { snapshots ->
+      snapshots!!.size shouldMatch equalTo(2)
+    }
+  }
+
+  @Test
+  fun `should fail if exception is thrown`() {
+    val configuration = getWorkConfiguration()
+    whenever(snapshotProvider.getAll(any())) doThrow
+      IllegalStateException("oh wow error")
+
+    Assertions.assertThrows(IllegalStateException::class.java) {
+      subject.preProcessCandidates(subject.getCandidates(getWorkConfiguration()).orEmpty(), configuration)
+    }
+  }
+
+  @Test
+  fun `should find cleanup candidates, apply exclusion policies on them and mark them`() {
+    val workConfiguration = getWorkConfiguration(
+      maxAgeDays = 1,
+      exclusionList = mutableListOf(
+        Exclusion()
+          .withType(ExclusionType.Allowlist.toString())
+          .withAttributes(
+            listOf(
+              Attribute()
+                .withKey("snapshotId")
+                .withValue(
+                  listOf("snap-000") // will exclude anything else not matching this imageId
+                )
+            )
+          )
+      )
+    )
+
+    whenever(dynamicConfigService.getConfig(any(), any(), eq(workConfiguration.maxItemsProcessedPerCycle))) doReturn
+      workConfiguration.maxItemsProcessedPerCycle
+
+    subject.mark(workConfiguration, postMark = { print("Done") })
+
+    // snap-111 is excluded by exclusion policies, specifically because snap-111 is not allowlisted
+    verify(applicationEventPublisher, times(1)).publishEvent(
+      check<MarkResourceEvent> { event ->
+        Assertions.assertTrue(event.markedResource.resourceId == "snap-000")
+      }
+    )
+
+    verify(resourceRepository, times(1)).upsert(any(), any())
+  }
+
+  @Test
+  fun `should not mark snapshots if they are not from a bake`() {
+    val params = Parameters(account = "1234", region = "us-east-1", environment = "test")
+    whenever(snapshotProvider.getAll(params)) doReturn listOf(
+      AmazonSnapshot(
+        volumeId = "vol-000",
+        state = "completed",
+        progress = "100%",
+        startTime = 1519943308000,
+        volumeSize = 10,
+        description = "i am a snapshot would you look at that",
+        snapshotId = "snap-000",
+        ownerId = "1234",
+        encrypted = false,
+        ownerAlias = null,
+        stateMessage = null
+      )
+    )
+
+    val workConfiguration = getWorkConfiguration()
+    whenever(dynamicConfigService.getConfig(any(), any(), eq(workConfiguration.maxItemsProcessedPerCycle))) doReturn
+      workConfiguration.maxItemsProcessedPerCycle
+
+    // description isn't from a bake, so it won't be marked
+    subject.mark(workConfiguration) { print { "postMark" } }
+    verify(applicationEventPublisher, times(0)).publishEvent(any<MarkResourceEvent>())
+    verify(resourceRepository, times(0)).upsert(any(), any())
+  }
+
+  private fun getWorkConfiguration(
+    isEnabled: Boolean = true,
+    dryRunMode: Boolean = false,
+    accountIds: List<String> = listOf("test"),
+    regions: List<String> = listOf("us-east-1"),
+    exclusionList: MutableList<Exclusion> = mutableListOf(),
+    maxAgeDays: Int = 1
+  ): WorkConfiguration {
+    val swabbieProperties = SwabbieProperties().apply {
+      dryRun = dryRunMode
+      providers = listOf(
+        CloudProviderConfiguration().apply {
+          name = "aws"
+          exclusions = mutableListOf()
+          accounts = accountIds
+          locations = regions
+          resourceTypes = listOf(
+            ResourceTypeConfiguration().apply {
+              name = "snapshot"
+              enabled = isEnabled
+              dryRun = dryRunMode
+              exclusions = exclusionList
+              retention = 2
+              maxAge = maxAgeDays
+            }
+          )
+        }
+      )
+    }
+
+    return WorkConfigurator(
+      swabbieProperties = swabbieProperties,
+      accountProvider = accountProvider,
+      exclusionPolicies = listOf(AccountExclusionPolicy()),
+      exclusionsSuppliers = Optional.empty()
+    ).generateWorkConfigurations()[0]
+  }
+}

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -270,8 +270,8 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
 
       val preProcessedCandidates = candidates
         .withResolvedOwners(workConfiguration)
-        .filter { !shouldExcludeResource(it, workConfiguration, optedOutResourceStates, Action.MARK) }
         .also { preProcessCandidates(it, workConfiguration) }
+        .filter { !shouldExcludeResource(it, workConfiguration, optedOutResourceStates, Action.MARK) }
 
       val maxItemsToProcess = Math.min(preProcessedCandidates.size, getMaxItemsProcessedPerCycle(workConfiguration))
 

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -231,7 +231,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
         ensureResourceUnmarked(resource, workConfiguration, "Resource no longer qualifies to be deleted")
         count += 1
         if (count >= swabbieProperties.maxUnmarkedPerCycle) {
-          log.warn("Unmarked ${swabbieProperties.maxUnmarkedPerCycle} resources (max allowed). Aborting.")
+          log.warn("Unmarked ${swabbieProperties.maxUnmarkedPerCycle} resources (max allowed) in $javaClass. Aborting.")
           return
         }
       }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Dates.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Dates.kt
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.swabbie
 
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 class Dates {
@@ -49,6 +51,12 @@ class Dates {
       }
 
       throw exception!!
+    }
+
+    fun toCreationDate(timestampMillis: Long) : String {
+      return LocalDateTime
+        .ofInstant(Instant.ofEpochMilli(timestampMillis), ZoneId.of("America/Los_Angeles"))
+        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSS'Z'"))
     }
   }
 }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/events/ResourceTrackingManager.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/events/ResourceTrackingManager.kt
@@ -25,7 +25,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
-import java.time.Clock
 
 /**
  * Handles any further change in state after a resource is updated

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
@@ -35,6 +35,7 @@ const val INSTANCE = "instance"
 const val LOAD_BALANCER = "loadBalancer"
 const val SERVER_GROUP = "serverGroup"
 const val LAUNCH_CONFIGURATION = "launchConfiguration"
+const val SNAPSHOT = "snapshot"
 
 /** Provider Types **/
 const val AWS = "aws"

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/UsedResourceRepository.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/UsedResourceRepository.kt
@@ -19,9 +19,12 @@
 package com.netflix.spinnaker.swabbie.repository
 
 /**
- * Track all snapshots that are in use by images
+ * Track a resource that is in use by another type of resource.
+ * This repository provides a way to collect information about use from one resource and query that while processing
+ *  another resource. For example, AWS provides some one way mappings about use (image -> snapshot). This repository
+ *  is used to record if a snapshot is in use by an image.
  */
-interface UsedSnapshotRepository {
-  fun recordUse(snapshotId: String, namespace: String)
-  fun isUsed(snapshotId: String, namespace: String): Boolean
+interface UsedResourceRepository {
+  fun recordUse(resourceType: String, id: String, namespace: String)
+  fun isUsed(resourceType: String, id: String, namespace: String): Boolean
 }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/UsedSnapshotRepository.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/UsedSnapshotRepository.kt
@@ -1,0 +1,27 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.repository
+
+/**
+ * Track all snapshots that are in use by images
+ */
+interface UsedSnapshotRepository {
+  fun recordUse(snapshotId: String, namespace: String)
+  fun isUsed(snapshotId: String, namespace: String): Boolean
+}

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisUsedResourceRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisUsedResourceRepository.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.swabbie.repository.UsedResourceRepository
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.util.concurrent.TimeUnit
 
@@ -33,7 +34,8 @@ class RedisUsedResourceRepository(
   private val redisClientDelegate: RedisClientDelegate = redisClientSelector.primary("default")
   private val log = LoggerFactory.getLogger(javaClass)
 
-  private val expTime = TimeUnit.DAYS.toSeconds(2).toInt()
+  @Value("\${swabbie.repository.used-resource-repository.retention-ttl:172800}")
+  private var expTime = TimeUnit.DAYS.toSeconds(2).toInt()
 
   init {
     log.info("Using ${javaClass.simpleName}")

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisUsedSnapshotRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisUsedSnapshotRepository.kt
@@ -1,0 +1,55 @@
+/*
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.redis
+
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
+import com.netflix.spinnaker.kork.jedis.RedisClientSelector
+import com.netflix.spinnaker.swabbie.repository.UsedSnapshotRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class RedisUsedSnapshotRepository(
+  redisClientSelector: RedisClientSelector
+) : UsedSnapshotRepository {
+
+  private val redisClientDelegate: RedisClientDelegate = redisClientSelector.primary("default")
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  private val SNAP_USED = "{swabbie:snapshot:used}"
+  private val expTime = TimeUnit.DAYS.toSeconds(2).toInt()
+
+  init {
+    log.info("Using ${javaClass.simpleName}")
+  }
+
+  override fun recordUse(snapshotId: String, namespace: String) {
+    redisClientDelegate.withCommandsClient { client ->
+      client.setex("$SNAP_USED:$snapshotId", expTime, namespace) //todo eb: is this the right thing to store?
+    }
+  }
+
+  override fun isUsed(snapshotId: String, namespace: String): Boolean {
+    return redisClientDelegate.withCommandsClient<Boolean> { client ->
+      val exists = client.get("$SNAP_USED:$snapshotId")
+      exists != null
+    }
+  }
+}


### PR DESCRIPTION
Mark snapshots. This will only mark things that fit the pattern of auto-snapshotted during a netflix bake. 

There's also a change to the image handler. Some background: AMIs contain a mapping to snapshots. Snapshots do not contain the mapping of what image they're a snapshot of. The change: as we go through the AMIs we record what snapshots they have, with at TTL of 2 days. We use this information in the snapshot handler to not delete snapshots which have been recorded here aka the image still exists for this snapshot.

Coming: deletion of snapshots via an orca task. It's marked as to-do right now.

An important note: you can't delete a snapshot of an ebs volume when the image it was taken from exists. So, there is really no harm in 'accidentally' deleting the snapshot.  