### PR TITLE
Add metrics for number of candidates processed

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -442,7 +442,10 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
     action: Action
   ) {
     val totalProcessed = Math.min(getMaxItemsProcessedPerCycle(workConfiguration), totalResourcesVisitedCounter.get())
-    registry.counter(numberOfCandidates.withTags("actionName", action.name)).increment()
+    registry.counter(numberOfCandidates.withTags(
+      "actionName", action.name,
+      "candidates", candidateCounter.get().toString()
+    )).increment()
     log.info("${action.name} Summary: {} candidates out of {} processed. {} scanned. {} excluded. Configuration: {}",
       candidateCounter.get(),
       totalProcessed,

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.swabbie
 
 import com.google.common.collect.Lists
+import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.patterns.PolledMeter
@@ -445,7 +446,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
     val totalProcessed = Math.min(getMaxItemsProcessedPerCycle(workConfiguration), totalResourcesVisitedCounter.get())
     PolledMeter.using(registry)
       .withId(numberOfCandidatesId)
-      .withTags(workConfiguration.resourceType)
+      .withTag(BasicTag(workConfiguration.resourceType,workConfiguration.resourceType))
       .monitorValue(candidateCounter.get())
 
     log.info("${action.name} Summary: {} candidates out of {} processed. {} scanned. {} excluded. Configuration: {}",

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -444,6 +444,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
     val totalProcessed = Math.min(getMaxItemsProcessedPerCycle(workConfiguration), totalResourcesVisitedCounter.get())
     registry.counter(numberOfCandidates.withTags(
       "actionName", action.name,
+      "resourceType", workConfiguration.resourceType,
       "candidates", candidateCounter.get().toString()
     )).increment()
     log.info("${action.name} Summary: {} candidates out of {} processed. {} scanned. {} excluded. Configuration: {}",


### PR DESCRIPTION
- We log the summary of number of candidates processed , adding these numbers as metrics to get better visibility into the health of the system 