### PR TITLE
fix(*): Override hashcode, equals in resource data class

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroup.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroup.kt
@@ -36,4 +36,12 @@ data class AmazonAutoScalingGroup(
   override val name: String = autoScalingGroupName,
   private val creationDate: String? =
     LocalDateTime.ofInstant(Instant.ofEpochMilli(createdTime), ZoneId.systemDefault()).toString()
-) : AmazonResource(creationDate)
+) : AmazonResource(creationDate) {
+  override fun equals(other: Any?): Boolean {
+    return super.equals(other)
+  }
+
+  override fun hashCode(): Int {
+    return super.hashCode()
+  }
+}

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImage.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImage.kt
@@ -34,7 +34,15 @@ data class AmazonImage(
   override val cloudProvider: String = AWS,
   override val name: String?,
   private val creationDate: String?
-) : AmazonResource(creationDate)
+) : AmazonResource(creationDate) {
+  override fun equals(other: Any?): Boolean {
+    return super.equals(other)
+  }
+
+  override fun hashCode(): Int {
+    return super.hashCode()
+  }
+}
 
 data class AmazonBlockDevice(
   val ebs: EbsBlockDevice?,

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/instances/AmazonInstance.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/instances/AmazonInstance.kt
@@ -42,4 +42,12 @@ data class AmazonInstance(
       .find { it.containsKey("aws:autoscaling:groupName") }
       ?.get("aws:autoscaling:groupName")
   }
+
+  override fun equals(other: Any?): Boolean {
+    return super.equals(other)
+  }
+
+  override fun hashCode(): Int {
+    return super.hashCode()
+  }
 }

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchconfigurations/LaunchConfiguration.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchconfigurations/LaunchConfiguration.kt
@@ -38,4 +38,11 @@ data class AmazonLaunchConfiguration(
 ) : AmazonResource(creationDate) {
   fun getAutoscalingGroupName() =
     launchConfigurationName.substringBeforeLast("-")
+  override fun equals(other: Any?): Boolean {
+    return super.equals(other)
+  }
+
+  override fun hashCode(): Int {
+    return super.hashCode()
+  }
 }

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonElasticLoadBalancer.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonElasticLoadBalancer.kt
@@ -29,4 +29,12 @@ data class AmazonElasticLoadBalancer(
   override val resourceId: String = loadBalancerName!!,
   override val cloudProvider: String = AWS,
   private val creationDate: String?
-) : AmazonResource(creationDate)
+) : AmazonResource(creationDate) {
+  override fun equals(other: Any?): Boolean {
+    return super.equals(other)
+  }
+
+  override fun hashCode(): Int {
+    return super.hashCode()
+  }
+}

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroup.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroup.kt
@@ -33,4 +33,12 @@ data class AmazonSecurityGroup(
   override val resourceType: String = SECURITY_GROUP,
   override val cloudProvider: String = AWS,
   private val creationDate: String?
-) : AmazonResource(creationDate)
+) : AmazonResource(creationDate) {
+  override fun equals(other: Any?): Boolean {
+    return super.equals(other)
+  }
+
+  override fun hashCode(): Int {
+    return super.hashCode()
+  }
+}

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
@@ -69,7 +69,7 @@ abstract class Resource : Excludable, Timestamped, HasDetails() {
       return true
     }
     return other is Resource &&
-      other.resourceId == this.resourceId && other.resourceType == this.resourceId
+      other.resourceId == this.resourceId && other.resourceType == this.resourceType
   }
 
   override fun hashCode(): Int {

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceOwnerResolverTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceOwnerResolverTest.kt
@@ -16,20 +16,18 @@
 
 package com.netflix.spinnaker.swabbie
 
-import com.fasterxml.jackson.annotation.JsonTypeName
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.should.shouldMatch
 import com.netflix.spectator.api.NoopRegistry
-import com.netflix.spinnaker.swabbie.model.Grouping
-import com.netflix.spinnaker.swabbie.model.GroupingType
+import com.netflix.spinnaker.swabbie.model.IMAGE
+import com.netflix.spinnaker.swabbie.model.INSTANCE
 import com.netflix.spinnaker.swabbie.model.Resource
+import com.netflix.spinnaker.swabbie.test.TestResource
 import org.junit.jupiter.api.Test
-import java.time.Instant
 
 object ResourceOwnerResolverTest {
-
-  private val resource = TestResource("1")
-  private val secondResource = TestResource(id = "2", resourceType = "type")
+  private val resource = TestResource("1", resourceType = IMAGE)
+  private val secondResource = TestResource("2", resourceType = INSTANCE)
 
   @Test
   fun `should resolve to single owner`() {
@@ -76,14 +74,3 @@ class TestStrategy : ResourceOwnerResolutionStrategy<Resource> {
   }
   override fun primaryFor(): Set<String> = setOf("image")
 }
-
-@JsonTypeName("Test")
-data class TestResource(
-    private val id: String,
-    override val resourceId: String = id,
-    override val name: String = "name",
-    override val resourceType: String = "image",
-    override val cloudProvider: String = "provider",
-    override val createTs: Long = Instant.parse("2018-05-24T12:34:56Z").toEpochMilli(),
-    override val grouping: Grouping? = Grouping("group", GroupingType.APPLICATION)
-) : Resource()

--- a/swabbie-front50/src/test/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategyTest.kt
+++ b/swabbie-front50/src/test/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategyTest.kt
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.swabbie.front50
 
-import com.fasterxml.jackson.annotation.JsonTypeName
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.should.shouldMatch
 import com.netflix.spectator.api.NoopRegistry
@@ -24,7 +23,7 @@ import com.netflix.spinnaker.swabbie.InMemoryCache
 import com.netflix.spinnaker.swabbie.model.Application
 import com.netflix.spinnaker.swabbie.model.Grouping
 import com.netflix.spinnaker.swabbie.model.GroupingType
-import com.netflix.spinnaker.swabbie.model.Resource
+import com.netflix.spinnaker.swabbie.test.TestResource
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
@@ -42,16 +41,12 @@ object ApplicationResourceOwnerResolutionStrategyTest {
         Application(name = "test", email = "test@netflix.com")
       )
 
-    subject.resolve(ResourceOne()) shouldMatch equalTo("name@netflix.com")
+    subject.resolve(
+      TestResource(
+        resourceId = "id",
+        name = "name",
+        grouping = Grouping("name", GroupingType.APPLICATION)
+      )
+    ) shouldMatch equalTo("name@netflix.com")
   }
 }
-
-@JsonTypeName("R")
-data class ResourceOne(
-  override val resourceId: String = "id",
-  override val name: String = "name",
-  override val resourceType: String = "type",
-  override val cloudProvider: String = "provider",
-  override val createTs: Long = System.currentTimeMillis(),
-  override val grouping: Grouping? = Grouping(name, GroupingType.APPLICATION)
-) : Resource()

--- a/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/TestResource.kt
+++ b/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/TestResource.kt
@@ -31,7 +31,15 @@ data class TestResource(
   override val name: String = resourceId,
   override val createTs: Long = Instant.now().minus(10, ChronoUnit.DAYS).toEpochMilli(),
   override val grouping: Grouping? = Grouping("group", GroupingType.APPLICATION)
-) : Resource()
+) : Resource() {
+  override fun equals(other: Any?): Boolean {
+    return super.equals(other)
+  }
+
+  override fun hashCode(): Int {
+    return super.hashCode()
+  }
+}
 
 const val TEST_RESOURCE_PROVIDER_TYPE = "testProvider"
 const val TEST_RESOURCE_TYPE = "testResourceType"


### PR DESCRIPTION
- add explicit equals and hashcode to data classes
- fix a bug on Resource.equals
- use TestResource from test where possible instead of creating new ones