### PR TITLE
chore(*): Update lock config

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -134,6 +134,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
         .toLowerCase()
       val lockOptions = LockOptions()
         .withLockName(normalizedLockName)
+        .withVersion(clock.millis())
         .withMaximumLockDuration(lockingService.get().swabbieMaxLockDuration)
       lockingService.get().acquireLock(lockOptions) {
         callback.invoke()
@@ -322,13 +323,13 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
               validMarkedIds.add(alreadyMarkedCandidate.resourceId)
             }
           }
+
+          unmarkResources(validMarkedIds, workConfiguration)
         } catch (e: Exception) {
           log.error("Failed while invoking ${javaClass.simpleName}", e)
           recordFailureForAction(Action.MARK, workConfiguration, e)
         }
       }
-
-      unmarkResources(validMarkedIds, workConfiguration)
 
       printResult(candidateCounter, totalResourcesVisitedCounter, workConfiguration, markedResources, Action.MARK)
     } finally {

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceTrackingRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceTrackingRepository.kt
@@ -122,7 +122,6 @@ class RedisResourceTrackingRepository(
       redisClientDelegate.withCommandsClient<Set<String>> { client ->
         client.hmget(SINGLE_RESOURCES_KEY, *subList.toTypedArray()).toSet()
       }?.mapNotNull { json ->
-        log.debug("Attempting to hydrate {}. Json document {}", subList, json)
         readMarkedResource(json)
       }
     }.flatten()
@@ -189,7 +188,11 @@ class RedisResourceTrackingRepository(
       }.toList()
     }
 
-  private fun readMarkedResource(resource: String): MarkedResource? {
+  private fun readMarkedResource(resource: String?): MarkedResource? {
+    if (resource == null) {
+      return null
+    }
+
     var markedResource: MarkedResource? = null
     try {
       markedResource = objectMapper.readValue(resource)


### PR DESCRIPTION
- Simplify lock to reuse version
- Moved unmarkResources inside the try..catch block
- Removed debug log
- Adjust readMarkedResource api param as nullable