### PR TITLE
fix(misc) : Fix to allow anonymous calls

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaEndpointProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaEndpointProvider.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.swabbie.aws.edda.providers
 
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.swabbie.EndpointProvider
 import com.netflix.spinnaker.swabbie.InMemoryCache
 import com.netflix.spinnaker.swabbie.aws.edda.EddaEndpointsService
@@ -36,4 +37,4 @@ class EddaEndpointProvider(
 @Component
 class EddaEndpointCache(
   eddaEndpointProvider: EddaEndpointProvider
-) : InMemoryCache<EddaEndpoint>(eddaEndpointProvider::load)
+) : InMemoryCache<EddaEndpoint>({ AuthenticatedRequest.allowAnonymous(eddaEndpointProvider::load) })

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/exclusions/BaseImageLabelsExclusionSupplier.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/exclusions/BaseImageLabelsExclusionSupplier.kt
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.config.Attribute
 import com.netflix.spinnaker.config.Exclusion
 import com.netflix.spinnaker.config.ExclusionType
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.swabbie.InMemoryCache
 import com.netflix.spinnaker.swabbie.exclusions.ExclusionsSupplier
 import com.netflix.spinnaker.swabbie.model.DynamicProperty
@@ -71,7 +72,7 @@ class BaseImageLabelsExclusionSupplier(
 class BaseImageLabelsCache(
   gateService: DynamicPropertyService
 ) : InMemoryCache<DynamicProperty>(
-  gateService.getProperties("bakery")::getPropertiesList
+  AuthenticatedRequest.allowAnonymous { gateService.getProperties("bakery")::getPropertiesList }
 )
 
 //TODO: make configurable

--- a/swabbie-clouddriver/src/main/kotlin/com/netflix/spinnaker/swabbie/clouddriver/ClouddriverAccountProvider.kt
+++ b/swabbie-clouddriver/src/main/kotlin/com/netflix/spinnaker/swabbie/clouddriver/ClouddriverAccountProvider.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.swabbie.clouddriver
 
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.swabbie.AccountProvider
 import com.netflix.spinnaker.swabbie.InMemoryCache
 import com.netflix.spinnaker.swabbie.model.Account
@@ -32,4 +33,4 @@ class ClouddriverAccountProvider(
 @Component
 class ClouddriverAccountCache(
   cloudDriverService: CloudDriverService
-) : InMemoryCache<SpinnakerAccount>(cloudDriverService::getAccounts)
+) : InMemoryCache<SpinnakerAccount>({ AuthenticatedRequest.allowAnonymous(cloudDriverService::getAccounts) })

--- a/swabbie-front50/src/main/kotlin/com/netflix/spinnaker/swabbie/front50/Front50ApplicationCache.kt
+++ b/swabbie-front50/src/main/kotlin/com/netflix/spinnaker/swabbie/front50/Front50ApplicationCache.kt
@@ -16,9 +16,10 @@
 
 package com.netflix.spinnaker.swabbie.front50
 
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.swabbie.InMemoryCache
 import com.netflix.spinnaker.swabbie.model.Application
 import org.springframework.stereotype.Component
 
 @Component
-class Front50ApplicationCache(front50Service: Front50Service) : InMemoryCache<Application>(front50Service::getApplications)
+class Front50ApplicationCache(front50Service: Front50Service) : InMemoryCache<Application>({ AuthenticatedRequest.allowAnonymous(front50Service::getApplications) })


### PR DESCRIPTION
- Explicitly allow anonymous calls for dependent services , This should address the issue of warning log messages that were seen.