### PR TITLE
fix(log+kork): bump kork and add logs for unmark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 buildscript {
   ext {
-    korkVersion = "5.2.6"
+    korkVersion = "5.3.4"
   }
   repositories {
     jcenter()

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -233,7 +233,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
     var count = 0
     for (resource in markedResourcesInNamespace) {
       if (!validMarkedResources.contains(resource.resourceId)) {
-        ensureResourceUnmarked(resource, workConfiguration, "Resource no longer qualifies to be deleted")
+        ensureResourceUnmarked(resource, workConfiguration, "Resource no longer qualifies to be deleted. Details: ${resource.resource.details}")
         count += 1
         if (count >= swabbieProperties.maxUnmarkedPerCycle) {
           log.warn("Unmarked ${swabbieProperties.maxUnmarkedPerCycle} resources (max allowed) in $javaClass. Aborting.")


### PR DESCRIPTION
* Bumping kork to try stay current.
* Adding a log statement with the details of a resource to see if we think it has been seen recently or something when it gets unmarked.