### PR TITLE
fix(header): Make request as anonymous

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaAmazonElasticLoadBalancerProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaAmazonElasticLoadBalancerProvider.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.swabbie.aws.edda.providers
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.EddaApiClient
 import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.swabbie.Parameters
 import com.netflix.spinnaker.swabbie.ResourceProvider
 import com.netflix.spinnaker.swabbie.aws.edda.EddaService
@@ -64,7 +65,7 @@ open class EddaAmazonElasticLoadBalancerProvider(
   private fun EddaService.getELBs(): List<AmazonElasticLoadBalancer> {
     return try {
       retrySupport.retry({
-        this.getLoadBalancers()
+        AuthenticatedRequest.allowAnonymous { this.getLoadBalancers() }
       }, maxRetries, retryBackOffMillis, true)
     } catch (e: Exception) {
       registry.counter(eddaFailureCountId.withTags("resourceType", LOAD_BALANCER)).increment()
@@ -77,7 +78,7 @@ open class EddaAmazonElasticLoadBalancerProvider(
     return try {
       retrySupport.retry({
         try {
-          this.getLoadBalancer(loadBalancerName)
+          AuthenticatedRequest.allowAnonymous { this.getLoadBalancer(loadBalancerName) }
         } catch (e: Exception) {
           if (e is RetrofitError && e.response.status == 404) {
             null

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaAmazonImageProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaAmazonImageProvider.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.swabbie.aws.edda.providers
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.EddaApiClient
 import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.swabbie.Parameters
 import com.netflix.spinnaker.swabbie.ResourceProvider
 import com.netflix.spinnaker.swabbie.aws.edda.EddaService
@@ -64,7 +65,7 @@ open class EddaAmazonImageProvider(
   private fun EddaService.getAmis(): List<AmazonImage> {
     return try {
       retrySupport.retry({
-        this.getImages()
+        AuthenticatedRequest.allowAnonymous { this.getImages() }
       }, maxRetries, retryBackOffMillis, true)
     } catch (e: Exception) {
       registry.counter(eddaFailureCountId.withTags("resourceType", IMAGE)).increment()
@@ -77,7 +78,7 @@ open class EddaAmazonImageProvider(
     return try {
       retrySupport.retry({
         try {
-          this.getImage(imageId)
+          AuthenticatedRequest.allowAnonymous { this.getImage(imageId) }
         } catch (e: Exception) {
           if (e is RetrofitError && e.response.status == 404) {
             null

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaAmazonSecurityGroupProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaAmazonSecurityGroupProvider.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.swabbie.aws.edda.providers
 
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.EddaApiClient
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.swabbie.Parameters
 import com.netflix.spinnaker.swabbie.ResourceProvider
 import com.netflix.spinnaker.swabbie.aws.securitygroups.AmazonSecurityGroup
@@ -37,7 +38,7 @@ open class EddaAmazonSecurityGroupProvider(
       accountId = params.account,
       environment = params.environment
     )?.run {
-      return getSecurityGroups()
+      return AuthenticatedRequest.allowAnonymous { getSecurityGroups() }
     }
 
     return emptyList()
@@ -49,7 +50,7 @@ open class EddaAmazonSecurityGroupProvider(
       accountId = params.account,
       environment = params.environment
     )?.run {
-      return getSecurityGroup(params.id)
+      return AuthenticatedRequest.allowAnonymous { getSecurityGroup(params.id) }
     }
 
     return null

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaAmazonSnapshotProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaAmazonSnapshotProvider.kt
@@ -21,6 +21,7 @@ package com.netflix.spinnaker.swabbie.aws.edda.providers
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.EddaApiClient
 import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.swabbie.Parameters
 import com.netflix.spinnaker.swabbie.ResourceProvider
 import com.netflix.spinnaker.swabbie.aws.edda.EddaService
@@ -66,7 +67,7 @@ open class EddaAmazonSnapshotProvider(
   private fun EddaService.getEbsSnapshots(): List<AmazonSnapshot> {
     return try {
       retrySupport.retry({
-        this.getSnapshots()
+        AuthenticatedRequest.allowAnonymous { this.getSnapshots() }
       }, maxRetries, retryBackOffMillis, true)
     } catch (e: Exception) {
       registry.counter(eddaFailureCountId.withTags("resourceType", SNAPSHOT)).increment()
@@ -79,7 +80,7 @@ open class EddaAmazonSnapshotProvider(
     return try {
       retrySupport.retry({
         try {
-          this.getSnapshot(snapshotId)
+          AuthenticatedRequest.allowAnonymous { this.getSnapshot(snapshotId) }
         } catch (e: Exception) {
           if (e is RetrofitError && e.response.status == 404) {
             null

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaApiSupport.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaApiSupport.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.swabbie.aws.edda.providers
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.EddaApiClient
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.swabbie.aws.edda.EddaService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -38,7 +39,7 @@ open class EddaApiSupport(
         return null
       }
 
-      return eddaClient.get()
+      return AuthenticatedRequest.allowAnonymous { eddaClient.get() }
     }
   }
 }

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaAutoScalingGroupProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaAutoScalingGroupProvider.kt
@@ -55,7 +55,7 @@ open class EddaAutoScalingGroupProvider(
       accountId = params.account,
       environment = params.environment
     )?.run {
-      return getServerGroup(params.id)
+      return AuthenticatedRequest.allowAnonymous { getServerGroup(params.id) }
     }
 
     return null

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaInstanceProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaInstanceProvider.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.swabbie.aws.edda.providers
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.EddaApiClient
 import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.swabbie.Parameters
 import com.netflix.spinnaker.swabbie.ResourceProvider
 import com.netflix.spinnaker.swabbie.aws.edda.EddaService
@@ -63,7 +64,7 @@ open class EddaInstanceProvider(
   private fun EddaService.getNonTerminatedInstances(): List<AmazonInstance> {
     return try {
       retrySupport.retry({
-        this.getInstances()
+        AuthenticatedRequest.allowAnonymous { this.getInstances() }
       }, maxRetries, retryBackOffMillis, true)
     } catch (e: Exception) {
       registry.counter(eddaFailureCountId.withTags("resourceType", INSTANCE)).increment()
@@ -76,7 +77,7 @@ open class EddaInstanceProvider(
     return try {
       retrySupport.retry({
         try {
-          this.getInstance(instanceId)
+          AuthenticatedRequest.allowAnonymous { this.getInstance(instanceId) }
         } catch (e: Exception) {
           if (e is RetrofitError && e.response.status == 404) {
             null

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaLaunchConfigurationProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/providers/EddaLaunchConfigurationProvider.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.swabbie.aws.edda.providers
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.EddaApiClient
 import com.netflix.spinnaker.kork.core.RetrySupport
+import com.netflix.spinnaker.security.AuthenticatedRequest
 import com.netflix.spinnaker.swabbie.Parameters
 import com.netflix.spinnaker.swabbie.ResourceProvider
 import com.netflix.spinnaker.swabbie.aws.edda.EddaService
@@ -63,7 +64,7 @@ open class EddaLaunchConfigurationProvider(
   private fun EddaService.getLaunchConfigurations(): List<AmazonLaunchConfiguration> {
     return try {
       retrySupport.retry({
-        this.getLaunchConfigs()
+        AuthenticatedRequest.allowAnonymous { this.getLaunchConfigs() }
       }, maxRetries, retryBackOffMillis, true)
     } catch (e: Exception) {
       registry.counter(eddaFailureCountId.withTags("resourceType", LAUNCH_CONFIGURATION)).increment()
@@ -76,7 +77,7 @@ open class EddaLaunchConfigurationProvider(
     return try {
       retrySupport.retry({
         try {
-          this.getLaunchConfig(launchConfigurationName)
+          AuthenticatedRequest.allowAnonymous { this.getLaunchConfig(launchConfigurationName) }
         } catch (e: Exception) {
           if (e is RetrofitError && e.response.status == 404) {
             null


### PR DESCRIPTION
- follow up to #203 , updated all `Edda` Providers