### PR TITLE
chore(dependencies): externalize versions to properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 buildscript {
-  ext {
-    korkVersion = "5.3.4"
-  }
   repositories {
     jcenter()
     maven { url "https://spinnaker.bintray.com/gradle" }
     maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
-    classpath "com.netflix.spinnaker.gradle:spinnaker-dev-plugin:6.5.0"
+    classpath "com.netflix.spinnaker.gradle:spinnaker-dev-plugin:$spinnakerGradleVersion"
     if (Boolean.valueOf(enablePublishing)) {
-      classpath "com.netflix.spinnaker.gradle:spinnaker-gradle-project:6.5.0"
+      classpath "com.netflix.spinnaker.gradle:spinnaker-gradle-project:$spinnakerGradleVersion"
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.parallel=true
-
 enablePublishing=false
+korkVersion=5.3.4
+spinnakerGradleVersion=6.5.0


### PR DESCRIPTION
doesn't actually change any versions, just moves version declarations to properties files for auto-PR from kork