### PR TITLE
feat(snapshots): add wait before delete

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandler.kt
@@ -39,6 +39,7 @@ import com.netflix.spinnaker.swabbie.notifications.Notifier
 import com.netflix.spinnaker.swabbie.orca.OrcaJob
 import com.netflix.spinnaker.swabbie.orca.OrcaService
 import com.netflix.spinnaker.swabbie.orca.OrchestrationRequest
+import com.netflix.spinnaker.swabbie.orca.generateWaitStageWithRandWaitTime
 import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
 import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
 import com.netflix.spinnaker.swabbie.repository.ResourceUseTrackingRepository
@@ -46,6 +47,7 @@ import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.repository.UsedResourceRepository
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.Clock
@@ -88,19 +90,30 @@ class AmazonSnapshotHandler(
   swabbieProperties,
   dynamicConfigService
 ) {
+
+  @Value("\${swabbie.agents.clean.interval-seconds:3600}")
+  private var cleanInterval: Long = 3600
+
+  /**
+   * Deletes resources in a two part request to stagger the deletion.
+   * First, we wait for a random amount of time.
+   * Then, we do the delete.
+   */
   override fun deleteResources(markedResources: List<MarkedResource>, workConfiguration: WorkConfiguration) {
     orcaService.orchestrate(
       OrchestrationRequest(
         // resources are partitioned based on grouping, so find the app to use from first resource
         application = applicationUtils.determineApp(markedResources.first().resource),
         job = listOf(
+          generateWaitStageWithRandWaitTime(cleanInterval),
           OrcaJob(
             type = "deleteSnapshot",
             context = mutableMapOf(
               "credentials" to workConfiguration.account.name,
               "snapshotIds" to markedResources.map { it.resourceId }.toSet(),
               "cloudProvider" to AWS,
-              "region" to workConfiguration.location
+              "region" to workConfiguration.location,
+              "requisiteStageRefIds" to listOf("0")
             )
           )
         ),

--- a/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaService.kt
+++ b/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaService.kt
@@ -78,3 +78,29 @@ class OrcaJob(
   context: MutableMap<String, Any?>
 ) : HashMap<String, Any?>(context.apply { put("type", type) }
 )
+
+/**
+ * Returns a random number of seconds, from 0 to [ceiling]
+ */
+private fun generateRandomWaitTimeS(ceiling: Long): Int {
+  val randNumber = Math.random()
+  return (ceiling * randNumber).toInt()
+}
+
+/**
+ * Generates a wait stage with a random wait time between 0 and [ceiling].
+ * This stage is meant to be used at the start of an orca task to stagger
+ * the start of many delete tasks, and the default [stageId] is 0.
+ *
+ * Optionally, you can add a [stageId] and [requisiteStageRefIds] to
+ * construct a stage you can place anywhere in your pipeline.
+ */
+fun generateWaitStageWithRandWaitTime(ceiling: Long, stageId: String = "0", requisiteStageRefIds: List<String> = emptyList()) =
+  OrcaJob(
+    type = "wait",
+    context = mutableMapOf(
+      "waitTime" to generateRandomWaitTimeS(ceiling),
+      "refId" to stageId,
+      "requisiteStageRefIds" to requisiteStageRefIds
+    )
+  )


### PR DESCRIPTION
Adding a wait stage before we delete the snapshot so that we stagger deletes across the entire clean interval. This will help us not blow through rate limits, and delete more things in a clean run.

If this is successful here, it's super easy to add to delete image.