### PR TITLE
fix(schedule): Fix for swabbie scheduling

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
@@ -26,9 +26,9 @@ import java.time.LocalTime
 import java.time.ZoneId
 
 /**
- * @param minImagesUsedByLC minimum number of images used by launch configurations that should be
+ * @param {@link #minImagesUsedByLC} minimum number of images used by launch configurations that should be
  *  in the cache. If not present agents will error to prevent mass marking in the case of edda problems.
- * @param minImagesUsedByInst minimum number of images used by instances that should be
+ * @param {@link #minImagesUsedByInst} minimum number of images used by instances that should be
  *  in the cache. If not present agents will error to prevent mass marking in the case of edda problems.
  */
 @ConfigurationProperties("swabbie")
@@ -190,31 +190,16 @@ class Schedule {
   var enabled: Boolean = true
   var startTime: String = "09:00"
   var endTime: String = "16:00"
-  val allowedDaysOfWeek: MutableList<DayOfWeek> = mutableListOf()
-  var defaultTimeZone: String = "America/Los_Angeles"
 
-  fun getResolvedDays(): List<DayOfWeek> {
-    return if (!enabled) {
-      mutableListOf(
-        DayOfWeek.MONDAY,
-        DayOfWeek.TUESDAY,
-        DayOfWeek.WEDNESDAY,
-        DayOfWeek.THURSDAY,
-        DayOfWeek.FRIDAY,
-        DayOfWeek.SATURDAY,
-        DayOfWeek.SUNDAY
-      )
-    } else if (allowedDaysOfWeek.isEmpty()) {
-      mutableListOf(
-        DayOfWeek.MONDAY,
-        DayOfWeek.TUESDAY,
-        DayOfWeek.WEDNESDAY,
-        DayOfWeek.THURSDAY
-      )
-    } else {
-      allowedDaysOfWeek
-    }
-  }
+  // default days overridable in config
+  var allowedDaysOfWeek: List<DayOfWeek> = listOf(
+    DayOfWeek.MONDAY,
+    DayOfWeek.TUESDAY,
+    DayOfWeek.WEDNESDAY,
+    DayOfWeek.THURSDAY
+  )
+
+  var defaultTimeZone: String = "America/Los_Angeles"
 
   fun getResolvedStartTime(): LocalTime {
     return LocalTime.parse(startTime)
@@ -232,12 +217,12 @@ class Schedule {
    * Returns proposed timestamp or next time in window
    */
   fun getNextTimeInWindow(proposedTimestamp: Long): Long {
-    return if (!enabled || getResolvedDays().isEmpty()) {
+    return if (!enabled) {
       proposedTimestamp
     } else {
       var day = dayFromTimestamp(proposedTimestamp)
       var incDays = 0
-      while (!getResolvedDays().contains(day)) {
+      while (!allowedDaysOfWeek.contains(day)) {
         day = day.plus(1)
         incDays += 1
       }

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/agents/ScheduledAgentTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/agents/ScheduledAgentTest.kt
@@ -1,23 +1,42 @@
 package com.netflix.spinnaker.swabbie.agents
 
 import com.netflix.spinnaker.config.Schedule
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.Month
 import java.time.ZoneId
 import java.time.ZoneOffset
+import java.time.LocalDate
+import java.time.DayOfWeek
 
 object ScheduledAgentTest {
 
   @Test
-  fun `monday 10 am is work time for normal schedule`() {
+  fun `should handle days according to schedule`() {
     val zoneId = ZoneId.of("America/Los_Angeles")
     val dateTime = LocalDateTime.of(2018, Month.SEPTEMBER, 17, 10, 0, 0) // a monday
     val instant = dateTime.toInstant(ZoneOffset.of("-7"))
     val clock = Clock.fixed(instant, zoneId)
 
-    assert(ScheduledAgent.timeToWork(Schedule(), clock))
+    assert(LocalDate.now(clock).dayOfWeek == DayOfWeek.MONDAY)
+
+    val schedule = Schedule()
+    schedule.allowedDaysOfWeek = listOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY)
+    assert(ScheduledAgent.timeToWork(schedule, clock))
+
+    schedule.allowedDaysOfWeek = listOf(DayOfWeek.TUESDAY)
+    assert(!ScheduledAgent.timeToWork(schedule, clock))
+
+    // startTime > endTime
+    schedule.startTime = "20:00"
+    schedule.endTime = "07:00"
+    schedule.allowedDaysOfWeek = listOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY)
+
+    Assertions.assertThrows(IllegalStateException::class.java, {
+      ScheduledAgent.timeToWork(schedule, clock)
+    }, "Scheduled startTime: ${schedule.startTime} cannot be after endTime: ${schedule.endTime}")
   }
 
   @Test
@@ -48,19 +67,5 @@ object ScheduledAgentTest {
     val clock = Clock.fixed(instant, zoneId)
 
     assert(!ScheduledAgent.timeToWork(Schedule(), clock))
-  }
-
-  @Test
-  fun `handle working all night (end time before start time)`() {
-    val zoneId = ZoneId.of("UTC")
-    val dateTime = LocalDateTime.of(2018, Month.SEPTEMBER, 18, 12, 0, 0) // tues at 5am PST, in UTC
-    val instant = dateTime.toInstant(ZoneOffset.UTC)
-    val clock = Clock.fixed(instant, zoneId)
-
-    val schedule = Schedule()
-    schedule.startTime = "21:00"
-    schedule.endTime = "07:00"
-
-    assert(ScheduledAgent.timeToWork(schedule, clock))
   }
 }


### PR DESCRIPTION
- remove double scheduling after caches are loaded
- refactored ScheduledAgent#timeToWork to not include off hours
- if off hours are needed, the config can be explicitly updated