### PR TITLE
fix(metrics): Fix delete metrics

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -569,7 +569,8 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
           if (!partition.isEmpty()) {
             try {
               deleteResources(partition, workConfiguration)
-              sendDeleteEvents(partition, workConfiguration)
+              partition
+                .forEach { it -> applicationEventPublisher.publishEvent(DeleteResourceEvent(it, workConfiguration))}
               candidateCounter.addAndGet(partition.size)
             } catch (e: Exception) {
               log.error("Failed to delete $it. Configuration: {}", workConfiguration.toLog(), e)
@@ -751,12 +752,6 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
         }
       }
     }
-  }
-
-  private fun sendDeleteEvents(
-    resources: List<MarkedResource>,
-    workConfiguration: WorkConfiguration
-  ) { resources.forEach { applicationEventPublisher.publishEvent(DeleteResourceEvent(it, workConfiguration)) }
   }
 
   private val Int.days: Period

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -569,8 +569,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
           if (!partition.isEmpty()) {
             try {
               deleteResources(partition, workConfiguration)
-              partition
-                .forEach { it -> applicationEventPublisher.publishEvent(DeleteResourceEvent(it, workConfiguration))}
+              partition.forEach { it -> applicationEventPublisher.publishEvent(DeleteResourceEvent(it, workConfiguration)) }
               candidateCounter.addAndGet(partition.size)
             } catch (e: Exception) {
               log.error("Failed to delete $it. Configuration: {}", workConfiguration.toLog(), e)

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -569,6 +569,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
           if (!partition.isEmpty()) {
             try {
               deleteResources(partition, workConfiguration)
+              sendDeleteEvents(partition, workConfiguration)
               candidateCounter.addAndGet(partition.size)
             } catch (e: Exception) {
               log.error("Failed to delete $it. Configuration: {}", workConfiguration.toLog(), e)
@@ -750,6 +751,12 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
         }
       }
     }
+  }
+
+  private fun sendDeleteEvents(
+    resources: List<MarkedResource>,
+    workConfiguration: WorkConfiguration
+  ) { resources.forEach { applicationEventPublisher.publishEvent(DeleteResourceEvent(it, workConfiguration)) }
   }
 
   private val Int.days: Period


### PR DESCRIPTION
- We were not publishing `DeleteResourceEvent` for delete action , adding that to take care of metrics issue.