### PR TITLE
Revert "fix(notification): Update notification context with spinnaker…

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
@@ -91,13 +91,12 @@ open class NotificationConfiguration(
   var itemsPerMessage: Int = 10,
   var resourceUrl: String = "",
   var defaultDestination: String = "swabbie@spinnaker.io",
-  var docsUrl: String = "",
-  var spinnakerWebUrl: String = ""
+  var docsUrl: String = ""
 ) {
   override fun toString(): String {
     return "NotificationConfiguration(" +
       "enabled=$enabled, types=$types, optOutBaseUrl='$optOutBaseUrl', itemsPerMessage=$itemsPerMessage, " +
-      "resourceUrl='$resourceUrl', defaultDestination='$defaultDestination', docsUrl='$docsUrl', spinnakerWebUrl='$spinnakerWebUrl')"
+      "resourceUrl='$resourceUrl', defaultDestination='$defaultDestination', docsUrl='$docsUrl')"
   }
 }
 

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -685,8 +685,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
             "configuration" to workConfiguration,
             "resourceType" to workConfiguration.resourceType.formatted(),
             "spinnakerLink" to workConfiguration.notificationConfiguration.resourceUrl,
-            "optOutLink" to workConfiguration.notificationConfiguration.optOutBaseUrl,
-            "spinnakerWebUrl" to workConfiguration.notificationConfiguration.spinnakerWebUrl
+            "optOutLink" to workConfiguration.notificationConfiguration.optOutBaseUrl
           )
 
           retrySupport.retry({


### PR DESCRIPTION
… webUrl (#224)"

This reverts commit 3440531305926e9cda41cd5b9e93445941e701dc.

As discussed with @jeyrschabu , reverting this change , ``spinnakerLink` can be used for the same.