### PR TITLE
fix(jitter): update config property for random jitter interval

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -96,8 +96,8 @@ class AmazonImageHandler(
   dynamicConfigService
 ) {
 
-  @Value("\${swabbie.agents.clean.interval-seconds:3600}")
-  private var cleanInterval: Long = 3600
+  @Value("\${swabbie.clean.jitter-interval:600}")
+  private var cleanInterval: Long = 600
 
   override fun deleteResources(markedResources: List<MarkedResource>, workConfiguration: WorkConfiguration) {
     orcaService.orchestrate(

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandler.kt
@@ -87,8 +87,8 @@ class AmazonSnapshotHandler(
   dynamicConfigService
 ) {
 
-  @Value("\${swabbie.agents.clean.interval-seconds:3600}")
-  private var cleanInterval: Long = 3600
+  @Value("\${swabbie.clean.jitter-interval:600}")
+  private var cleanInterval: Long = 600
 
   /**
    * Deletes resources in a two part request to stagger the deletion.


### PR DESCRIPTION
We lost this config property when we switched to a work queue. Giving this important property a proper name and default value. 