### PR TITLE
fix(images): actually run the image handler

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
@@ -21,41 +21,22 @@ import com.amazonaws.services.securitytoken.AWSSecurityTokenService
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.kork.aws.bastion.BastionConfig
-import com.netflix.spinnaker.kork.core.RetrySupport
-import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.swabbie.AccountProvider
 import com.netflix.spinnaker.swabbie.CachedViewProvider
-import com.netflix.spinnaker.swabbie.InMemorySingletonCache
-import com.netflix.spinnaker.swabbie.ResourceOwnerResolver
 import com.netflix.spinnaker.swabbie.aws.AWS
 import com.netflix.spinnaker.swabbie.aws.Vanilla
 import com.netflix.spinnaker.swabbie.aws.caches.AmazonImagesUsedByInstancesCache
-import com.netflix.spinnaker.swabbie.aws.caches.ImagesUsedByInstancesProvider
+import com.netflix.spinnaker.swabbie.aws.caches.AmazonImagesUsedByInstancesInMemoryCache
 import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchConfigurationCache
 import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchConfigurationInMemoryCache
+import com.netflix.spinnaker.swabbie.aws.caches.ImagesUsedByInstancesProvider
 import com.netflix.spinnaker.swabbie.aws.caches.LaunchConfigurationCacheProvider
-import com.netflix.spinnaker.swabbie.aws.caches.AmazonImagesUsedByInstancesInMemoryCache
-import com.netflix.spinnaker.swabbie.aws.images.AmazonImage
-import com.netflix.spinnaker.swabbie.aws.images.AmazonImageHandler
-import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
 import com.netflix.spinnaker.swabbie.model.IMAGE
-import com.netflix.spinnaker.swabbie.model.Rule
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
-import com.netflix.spinnaker.swabbie.notifications.Notifier
-import com.netflix.spinnaker.swabbie.orca.OrcaService
-import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
-import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
-import com.netflix.spinnaker.swabbie.repository.ResourceUseTrackingRepository
-import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
-import com.netflix.spinnaker.swabbie.repository.UsedResourceRepository
-import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import java.rmi.registry.Registry
 import java.time.Clock
 
 @Configuration
@@ -93,7 +74,6 @@ open class AwsConfiguration {
   }
 
   @Bean
-  @ConditionalOnBean(LaunchConfigurationCacheProvider::class)
   open fun launchConfigurationInMemoryCache(
     provider: CachedViewProvider<AmazonLaunchConfigurationCache>
   ): AmazonLaunchConfigurationInMemoryCache {
@@ -101,7 +81,6 @@ open class AwsConfiguration {
   }
 
   @Bean
-  @ConditionalOnBean(ImagesUsedByInstancesProvider::class)
   open fun imagesUsedByInstancesInMemoryCache(
     provider: CachedViewProvider<AmazonImagesUsedByInstancesCache>
   ): AmazonImagesUsedByInstancesInMemoryCache {
@@ -124,55 +103,5 @@ open class AwsConfiguration {
     accountProvider: AccountProvider
   ): AWS {
     return Vanilla(sts, objectMapper, accountProvider)
-  }
-
-  @Bean
-  @ConditionalOnBean(
-    value = [AmazonImagesUsedByInstancesInMemoryCache::class, AmazonLaunchConfigurationInMemoryCache::class]
-  )
-  open fun amazonImageHandler(
-    registry: com.netflix.spectator.api.Registry,
-    clock: Clock,
-    notifiers: List<Notifier>,
-    resourceTrackingRepository: ResourceTrackingRepository,
-    resourceStateRepository: ResourceStateRepository,
-    resourceOwnerResolver: ResourceOwnerResolver<AmazonImage>,
-    exclusionPolicies: List<ResourceExclusionPolicy>,
-    applicationEventPublisher: ApplicationEventPublisher,
-    retrySupport: RetrySupport,
-    dynamicConfigService: DynamicConfigService,
-    launchConfigurationCache: InMemorySingletonCache<AmazonLaunchConfigurationCache>,
-    imagesUsedByinstancesCache: InMemorySingletonCache<AmazonImagesUsedByInstancesCache>,
-    rules: List<Rule<AmazonImage>>,
-    aws: AWS,
-    orcaService: OrcaService,
-    applicationUtils: ApplicationUtils,
-    taskTrackingRepository: TaskTrackingRepository,
-    resourceUseTrackingRepository: ResourceUseTrackingRepository,
-    usedResourceRepository: UsedResourceRepository,
-    swabbieProperties: SwabbieProperties
-  ): AmazonImageHandler{
-    return AmazonImageHandler(
-      registry,
-      clock,
-      notifiers,
-      resourceTrackingRepository,
-      resourceStateRepository,
-      resourceOwnerResolver,
-      exclusionPolicies,
-      applicationEventPublisher,
-      retrySupport,
-      dynamicConfigService,
-      launchConfigurationCache,
-      imagesUsedByinstancesCache,
-      rules,
-      aws,
-      orcaService,
-      applicationUtils,
-      taskTrackingRepository,
-      resourceUseTrackingRepository,
-      usedResourceRepository,
-      swabbieProperties
-    )
   }
 }

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -22,13 +22,11 @@ import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.swabbie.AbstractResourceTypeHandler
 import com.netflix.spinnaker.swabbie.InMemorySingletonCache
-import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.ResourceOwnerResolver
 import com.netflix.spinnaker.swabbie.aws.AWS
+import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.aws.caches.AmazonImagesUsedByInstancesCache
-import com.netflix.spinnaker.swabbie.aws.caches.AmazonImagesUsedByInstancesInMemoryCache
 import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchConfigurationCache
-import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchConfigurationInMemoryCache
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.exception.CacheSizeException
 import com.netflix.spinnaker.swabbie.exception.StaleCacheException
@@ -54,13 +52,13 @@ import com.netflix.spinnaker.swabbie.repository.UsedResourceRepository
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
 import net.logstash.logback.argument.StructuredArguments.kv
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.Clock
 import java.time.Duration
 import kotlin.system.measureTimeMillis
 
+@Component
 class AmazonImageHandler(
   registry: Registry,
   clock: Clock,

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -61,10 +61,6 @@ import java.time.Clock
 import java.time.Duration
 import kotlin.system.measureTimeMillis
 
-@ConditionalOnBean(
-  value = [AmazonImagesUsedByInstancesInMemoryCache::class, AmazonLaunchConfigurationInMemoryCache::class]
-)
-@Component
 class AmazonImageHandler(
   registry: Registry,
   clock: Clock,

--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ControllerUtils.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ControllerUtils.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.kork.web.exceptions.NotFoundException
 import com.netflix.spinnaker.swabbie.ResourceTypeHandler
 import com.netflix.spinnaker.swabbie.model.SwabbieNamespace
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
@@ -11,6 +12,13 @@ class ControllerUtils(
   private val resourceTypeHandlers: List<ResourceTypeHandler<*>>,
   private val workConfigurations: List<WorkConfiguration>
 ) {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  init {
+    log.info("Available resource type handlers are: $resourceTypeHandlers")
+  }
+
   fun findWorkConfiguration(namespace: SwabbieNamespace): WorkConfiguration {
     return workConfigurations.find { workConfiguration ->
       workConfiguration.account.name == namespace.accountName &&


### PR DESCRIPTION
the image handler was broken because we were conditionally wiring things wrong. Removing the conditionals since they're not based on config properties and should always be wired in for now.