### PR TITLE
fix(serverGroups): make all caches required

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
@@ -31,7 +31,6 @@ import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchConfigurationCache
 import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchConfigurationInMemoryCache
 import com.netflix.spinnaker.swabbie.aws.caches.ImagesUsedByInstancesProvider
 import com.netflix.spinnaker.swabbie.aws.caches.LaunchConfigurationCacheProvider
-import com.netflix.spinnaker.swabbie.model.IMAGE
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
@@ -51,11 +50,7 @@ open class AwsConfiguration {
     workConfigurations: List<WorkConfiguration>,
     accountProvider: AccountProvider,
     aws: AWS
-  ): CachedViewProvider<AmazonImagesUsedByInstancesCache>? {
-    if (workConfigurations.none { it.resourceType == IMAGE }) {
-      return null
-    }
-
+  ): CachedViewProvider<AmazonImagesUsedByInstancesCache> {
     return ImagesUsedByInstancesProvider(clock, accountProvider, aws)
   }
 
@@ -65,11 +60,7 @@ open class AwsConfiguration {
     workConfigurations: List<WorkConfiguration>,
     accountProvider: AccountProvider,
     aws: AWS
-  ): CachedViewProvider<AmazonLaunchConfigurationCache>? {
-    if (workConfigurations.none { it.resourceType == IMAGE }) {
-      return null
-    }
-
+  ): CachedViewProvider<AmazonLaunchConfigurationCache> {
     return LaunchConfigurationCacheProvider(clock, workConfigurations, accountProvider, aws)
   }
 


### PR DESCRIPTION
In theory we'd like to only have the caches needed for each resource group populate. In practice, there's some mixing of cache use. This PR fully removes the conditional beans so that we can enable server groups again.

In the future we need to re-evaluate this cache sharing or clearly have required caches for each resource type.