### PR TITLE
fix(work): allow you to configure which actions run

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.config
 
+import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.model.EmptyNotificationConfiguration
 import org.springframework.boot.context.properties.ConfigurationProperties
 import java.time.DayOfWeek
@@ -138,6 +139,7 @@ class Exclusion {
 
 class ResourceTypeConfiguration {
   var enabled: Boolean = false
+  var enabledActions: List<Action> = mutableListOf(Action.MARK, Action.NOTIFY, Action.DELETE)
   var dryRun: Boolean = true
   var retention: Int = 14
   var exclusions: MutableSet<Exclusion> = mutableSetOf()

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/WorkConfigurator.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/WorkConfigurator.kt
@@ -99,7 +99,8 @@ open class WorkConfigurator(
               entityTaggingEnabled = resourceTypeConfiguration.entityTaggingEnabled,
               maxAge = resourceTypeConfiguration.maxAge,
               maxItemsProcessedPerCycle = cloudProviderConfiguration.maxItemsProcessedPerCycle,
-              itemsProcessedBatchSize = cloudProviderConfiguration.itemsProcessedBatchSize
+              itemsProcessedBatchSize = cloudProviderConfiguration.itemsProcessedBatchSize,
+              enabledActions = resourceTypeConfiguration.enabledActions
             ).let { configuration ->
               configuration.takeIf {
                 !shouldExclude(account, it, exclusionPolicies, log)

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/WorkConfiguration.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/WorkConfiguration.kt
@@ -19,9 +19,10 @@ package com.netflix.spinnaker.swabbie.model
 import com.netflix.spinnaker.config.Exclusion
 import com.netflix.spinnaker.config.NotificationConfiguration
 import com.netflix.spinnaker.swabbie.events.Action
+import org.slf4j.LoggerFactory
 
 /**
- * @param retention How many days swabbie will wait until starting the deletion process (soft delete, then delete)
+ * @param retention How many days swabbie will wait until starting the deletion process
  * @param maxAge resources newer than the maxAge in days will be excluded
  */
 data class WorkConfiguration(
@@ -37,12 +38,15 @@ data class WorkConfiguration(
   val notificationConfiguration: NotificationConfiguration = EmptyNotificationConfiguration(),
   val maxAge: Int = 14,
   val maxItemsProcessedPerCycle: Int = 10,
-  val itemsProcessedBatchSize: Int = 5
+  val itemsProcessedBatchSize: Int = 5,
+  val enabledActions: List<Action> = listOf(Action.MARK, Action.NOTIFY, Action.DELETE)
 ) {
+  private val log = LoggerFactory.getLogger(javaClass)
 
   fun toLog(): String = "$namespace/$account/$location/$cloudProvider/$resourceType"
   fun toWorkItems(): List<WorkItem> {
-    return listOf(Action.MARK, Action.NOTIFY, Action.DELETE).map {
+    log.info("Actions $enabledActions enabled for ${toLog()}")
+    return enabledActions.map {
       WorkItem(id = "${it.name}:$namespace".toLowerCase(), workConfiguration = this, action = it)
     }
   }

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/model/WorkConfigurationTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/model/WorkConfigurationTest.kt
@@ -49,4 +49,31 @@ object WorkConfigurationTest {
       assert(setOf(workConfiguration) == map { it.workConfiguration }.toSet())
     }
   }
+
+  @Test
+  fun `should only use enabled actions`() {
+    val workConfiguration = WorkConfiguration(
+      namespace = "workConfiguration1",
+      account = SpinnakerAccount(
+        name = "test",
+        accountId = "id",
+        type = "type",
+        edda = "",
+        regions = emptyList(),
+        eddaEnabled = false,
+        environment = "test"
+      ),
+      location = "us-east-1",
+      cloudProvider = AWS,
+      resourceType = "testResourceType",
+      retention = 14,
+      exclusions = emptySet(),
+      maxAge = 1,
+      enabledActions = listOf(Action.MARK)
+    )
+
+    val workItems = workConfiguration.toWorkItems()
+    assert(workItems.size == 1)
+    assert(workItems[0].action == Action.MARK)
+  }
 }


### PR DESCRIPTION
This adds the ability to configure which actions you want to run for each resource. This allows you to not run delete for some or all the resources you're marking (like, say, locally).