### PR TITLE
fix(caching): add to sets instead of replace whole set

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/ImagesUsedByInstancesProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/ImagesUsedByInstancesProvider.kt
@@ -33,7 +33,7 @@ class ImagesUsedByInstancesProvider(
   private val log: Logger = LoggerFactory.getLogger(javaClass)
   override fun load(): AmazonImagesUsedByInstancesCache {
     log.info("Loading cache for ${javaClass.simpleName}")
-    val refdAmisByRegion = mutableMapOf<String, Set<String>>()
+    val refdAmisByRegion = mutableMapOf<String, MutableSet<String>>()
     accountProvider.getAccounts()
       .filter { it.cloudProvider == "aws" && !it.regions.isNullOrEmpty() }
       .forEach { account ->
@@ -53,7 +53,9 @@ class ImagesUsedByInstancesProvider(
             .map { it.imageId }
             .toSet()
 
-          refdAmisByRegion[region.name] = refdAmis.toSet()
+          val currentAmis = refdAmisByRegion.getOrDefault(region.name, mutableSetOf())
+          currentAmis.addAll(refdAmis)
+          refdAmisByRegion[region.name] = currentAmis
         }
       }
 

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/LaunchConfigurationCacheProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/LaunchConfigurationCacheProvider.kt
@@ -43,7 +43,7 @@ class LaunchConfigurationCacheProvider(
     accountProvider.getAccounts()
       .filter(isCorrectCloudProviderAndRegion(configuredRegions))
       .forEach { account ->
-        account.regions!!.forEach { region ->
+        account.regions?.forEach { region ->
           log.info("Reading launch configurations in {}/{}/{}", account.accountId, region.name, account.environment)
           val launchConfigs: Set<AmazonLaunchConfiguration> = getLaunchConfigurations(
             Parameters(
@@ -58,7 +58,9 @@ class LaunchConfigurationCacheProvider(
             refdAmis.getOrPut(it.imageId) { mutableSetOf() }.add(it)
           }
 
-          refdAmisByRegion[region.name] = refdAmis
+          val currentAmis = refdAmisByRegion.getOrDefault(region.name, mutableMapOf())
+          currentAmis.putAll(refdAmis)
+          refdAmisByRegion[region.name] = currentAmis
         }
       }
 
@@ -66,5 +68,6 @@ class LaunchConfigurationCacheProvider(
   }
 
   private fun isCorrectCloudProviderAndRegion(configuredRegions: Set<String>) =
-    { account: Account -> account.cloudProvider == "aws" && !account.regions.isNullOrEmpty() && account.regions!!.any { it.name in configuredRegions } }
+    { account: Account ->
+      account.cloudProvider == "aws" && !account.regions.isNullOrEmpty() && account.regions!!.any { it.name in configuredRegions } }
 }


### PR DESCRIPTION
We need to update each set instead of replacing it so that we keep track of all image use info, not just for the last account we check.