### PR TITLE
Rest when disabled

### DIFF
--- a/swabbie-aws/swabbie-aws.gradle
+++ b/swabbie-aws/swabbie-aws.gradle
@@ -26,6 +26,9 @@ dependencies {
   implementation "com.amazonaws:aws-java-sdk-sts"
   implementation "com.amazonaws:aws-java-sdk-elasticloadbalancing"
   implementation "com.netflix.frigga:frigga"
+  implementation "com.netflix.spinnaker.moniker:moniker"
+  implementation "net.logstash.logback:logstash-logback-encoder"
+  implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
 
   testImplementation project(":swabbie-test")
 }

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CacheStatus.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CacheStatus.kt
@@ -63,7 +63,3 @@ open class InMemoryCacheStatus(
     return allLoaded.get()
   }
 }
-
-open class NoopCacheStatus : CacheStatus {
-  override fun cachesLoaded() = true
-}

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/WorkConfiguration.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/WorkConfiguration.kt
@@ -43,7 +43,7 @@ data class WorkConfiguration(
 ) {
   private val log = LoggerFactory.getLogger(javaClass)
 
-  fun toLog(): String = "$namespace/$account/$location/$cloudProvider/$resourceType"
+  fun toLog(): String = "$namespace/${account.accountId}/$location/$cloudProvider/$resourceType"
   fun toWorkItems(): List<WorkItem> {
     log.info("Actions $enabledActions enabled for ${toLog()}")
     return enabledActions.map {

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/tagging/ResourceEntityTagger.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/tagging/ResourceEntityTagger.kt
@@ -60,10 +60,11 @@ class ResourceEntityTagger(
   }
 
   private fun tagMessage(markedResource: MarkedResource, workConfiguration: WorkConfiguration): String {
-    return markedResource.summaries
+    val summaries = markedResource.summaries
       .joinToString(", ") {
         it.description
-      }.also { summary -> return formatMessage(summary, markedResource, workConfiguration) }
+      }
+    return formatMessage(summaries, markedResource, workConfiguration)
   }
 
   private fun formatMessage(message: String, markedResource: MarkedResource, workConfiguration: WorkConfiguration): String {

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManagerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManagerTest.kt
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.swabbie.events
 
 import com.netflix.spectator.api.NoopRegistry
-import com.netflix.spinnaker.swabbie.ResourceTypeHandlerTest.workConfiguration
 import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.ResourceState
 import com.netflix.spinnaker.swabbie.model.Status
@@ -28,6 +27,7 @@ import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.tagging.ResourceTagger
 import com.netflix.spinnaker.swabbie.tagging.TaggingService
 import com.netflix.spinnaker.swabbie.test.TestResource
+import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.argWhere
@@ -52,7 +52,7 @@ object ResourceStateManagerTest {
 
   private var resource = TestResource("testResource")
   private var imageResource = TestResource(resourceId = "testImageResource", resourceType = "image")
-  private var configuration = workConfiguration()
+  private var configuration = WorkConfigurationTestHelper.generateWorkConfiguration()
   private val applicationUtils = ApplicationUtils(emptyList())
 
   private val markedResourceWithViolations = MarkedResource(

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceTrackingManagerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceTrackingManagerTest.kt
@@ -19,11 +19,11 @@
 package com.netflix.spinnaker.swabbie.events
 
 import com.netflix.spectator.api.NoopRegistry
-import com.netflix.spinnaker.swabbie.ResourceTypeHandlerTest.workConfiguration
 import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
 import com.netflix.spinnaker.swabbie.test.TestResource
+import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
 import com.nhaarman.mockito_kotlin.argWhere
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
@@ -38,7 +38,7 @@ object ResourceTrackingManagerTest {
   private val registry = NoopRegistry()
 
   private var resource = TestResource("testResource")
-  private var configuration = workConfiguration()
+  private var configuration = WorkConfigurationTestHelper.generateWorkConfiguration()
 
   private var subject = ResourceTrackingManager(
     resourceTrackingRepository = resourceTrackingRepository,

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkProcessorTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkProcessorTest.kt
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.swabbie.work
 
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.swabbie.LockingService
-import com.netflix.spinnaker.swabbie.NoopCacheStatus
 import com.netflix.spinnaker.swabbie.ResourceTypeHandler
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.SpinnakerAccount
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.test.InMemoryWorkQueue
+import com.netflix.spinnaker.swabbie.test.NoopCacheStatus
 import com.netflix.spinnaker.swabbie.test.TestResource
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkProcessorTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkProcessorTest.kt
@@ -16,65 +16,38 @@
 
 package com.netflix.spinnaker.swabbie.work
 
+import com.netflix.appinfo.InstanceInfo.InstanceStatus.DOWN
+import com.netflix.appinfo.InstanceInfo.InstanceStatus.UP
+import com.netflix.discovery.StatusChangeEvent
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
 import com.netflix.spinnaker.swabbie.LockingService
 import com.netflix.spinnaker.swabbie.ResourceTypeHandler
 import com.netflix.spinnaker.swabbie.events.Action
-import com.netflix.spinnaker.swabbie.model.AWS
-import com.netflix.spinnaker.swabbie.model.SpinnakerAccount
-import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.test.InMemoryWorkQueue
 import com.netflix.spinnaker.swabbie.test.NoopCacheStatus
 import com.netflix.spinnaker.swabbie.test.TestResource
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.whenever
+import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.reset
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
 import java.time.Clock
 
 object WorkProcessorTest {
-  private val workConfiguration1 = WorkConfiguration(
-    namespace = "workConfiguration1",
-    account = SpinnakerAccount(
-      name = "test",
-      accountId = "id",
-      type = "type",
-      edda = "",
-      regions = emptyList(),
-      eddaEnabled = false,
-      environment = "test"
-    ),
-    location = "us-east-1",
-    cloudProvider = AWS,
-    resourceType = "testResourceType",
-    retention = 14,
-    exclusions = emptySet(),
-    maxAge = 1
-  )
+  private val workConfiguration1 = WorkConfigurationTestHelper
+    .generateWorkConfiguration(namespace = "workConfiguration1")
 
-  private val workConfiguration2 = WorkConfiguration(
-    namespace = "workConfiguration2",
-    account = SpinnakerAccount(
-      name = "test",
-      accountId = "id",
-      type = "type",
-      edda = "",
-      regions = emptyList(),
-      eddaEnabled = false,
-      environment = "test"
-    ),
-    location = "us-east-1",
-    cloudProvider = AWS,
-    resourceType = "testResourceType",
-    retention = 14,
-    exclusions = emptySet(),
-    maxAge = 1
-  )
+  private val workConfiguration2 = WorkConfigurationTestHelper
+    .generateWorkConfiguration(namespace = "workConfiguration2")
 
   private val workQueue = InMemoryWorkQueue(_seed = listOf(workConfiguration1, workConfiguration2))
   private val handler1 = mock<ResourceTypeHandler<TestResource>>()
@@ -89,10 +62,15 @@ object WorkProcessorTest {
     cacheStatus = NoopCacheStatus()
   )
 
+  // StatusChangeEvent(previous, current)
+  private val upEvent = RemoteStatusChangedEvent(StatusChangeEvent(DOWN, UP))
+  private val downEvent = RemoteStatusChangedEvent(StatusChangeEvent(UP, DOWN))
+
   @BeforeEach
   fun setup() {
     workQueue.clear()
     reset(handler1, handler2)
+    processor.onDiscoveryUpCallback(upEvent)
   }
 
   @Test
@@ -129,7 +107,7 @@ object WorkProcessorTest {
     verify(handler2).notify(workConfiguration2)
     verify(handler2).delete(workConfiguration2)
 
-    assert(workQueue.isEmpty())
+    expectThat(workQueue.isEmpty()).isTrue()
   }
 
   @Test
@@ -159,6 +137,15 @@ object WorkProcessorTest {
     verify(handler2, never()).notify(workConfiguration2)
     verify(handler2, never()).delete(workConfiguration2)
 
-    assert(workQueue.isEmpty())
+    expectThat(workQueue.isEmpty()).isTrue()
+  }
+
+  @Test
+  fun `should not process work when disabled`() {
+    processor.onDiscoveryDownCallback(downEvent)
+    workQueue.seed()
+    processor.process()
+
+    expectThat(workQueue.isEmpty()).isFalse()
   }
 }

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManagerScheduleTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManagerScheduleTest.kt
@@ -1,0 +1,90 @@
+/*
+ *
+ *  * Copyright 2018 Netflix, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License")
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.work
+
+import com.netflix.spinnaker.config.Schedule
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.api.expectThrows
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+import java.time.Clock
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.Month
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+object WorkQueueManagerScheduleTest {
+
+  @Test
+  fun `should handle days according to schedule`() {
+    val zoneId = ZoneId.of("America/Los_Angeles")
+    val dateTime = LocalDateTime.of(2018, Month.SEPTEMBER, 17, 10, 0, 0) // a monday
+    val instant = dateTime.toInstant(ZoneOffset.of("-7"))
+    val clock = Clock.fixed(instant, zoneId)
+
+    expectThat(LocalDate.now(clock).dayOfWeek == DayOfWeek.MONDAY).isTrue()
+
+    val schedule = Schedule()
+    schedule.allowedDaysOfWeek = listOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY)
+    expectThat(WorkQueueManager.timeToWork(schedule, clock)).isTrue()
+
+    schedule.allowedDaysOfWeek = listOf(DayOfWeek.TUESDAY)
+    expectThat(WorkQueueManager.timeToWork(schedule, clock)).isFalse()
+
+    // startTime > endTime
+    schedule.startTime = "20:00"
+    schedule.endTime = "07:00"
+    schedule.allowedDaysOfWeek = listOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY)
+
+    expectThrows<IllegalStateException> { WorkQueueManager.timeToWork(schedule, clock) }
+  }
+
+  @Test
+  fun `monday 8 am not work time for normal schedule`() {
+    val zoneId = ZoneId.of("America/Los_Angeles")
+    val dateTime = LocalDateTime.of(2018, Month.SEPTEMBER, 17, 16, 0, 0) // a monday
+    val instant = dateTime.toInstant(ZoneOffset.of("-7"))
+    val clock = Clock.fixed(instant, zoneId)
+
+    expectThat(WorkQueueManager.timeToWork(Schedule(), clock)).isFalse()
+  }
+
+  @Test
+  fun `handle clock in UTC, work tues at 10am`() {
+    val zoneId = ZoneId.of("UTC")
+    val dateTime = LocalDateTime.of(2018, Month.SEPTEMBER, 18, 17, 0, 0) // tues at 10am PST, in UTC
+    val instant = dateTime.toInstant(ZoneOffset.UTC)
+    val clock = Clock.fixed(instant, zoneId)
+
+    expectThat(WorkQueueManager.timeToWork(Schedule(), clock)).isTrue()
+  }
+
+  @Test
+  fun `handle clock in UTC, don't work tues at 8am`() {
+    val zoneId = ZoneId.of("UTC")
+    val dateTime = LocalDateTime.of(2018, Month.SEPTEMBER, 18, 15, 0, 0) // tues at 8am PST, in UTC
+    val instant = dateTime.toInstant(ZoneOffset.UTC)
+    val clock = Clock.fixed(instant, zoneId)
+
+    expectThat(WorkQueueManager.timeToWork(Schedule(), clock)).isFalse()
+  }
+}

--- a/swabbie-core/swabbie-core.gradle
+++ b/swabbie-core/swabbie-core.gradle
@@ -15,19 +15,18 @@
  */
 
 dependencies {
-  compile "org.slf4j:jcl-over-slf4j"
-  compile "com.netflix.spinnaker.kork:kork-core"
-  compile "com.netflix.spinnaker.kork:kork-web"
-  compile "net.logstash.logback:logstash-logback-encoder"
-  compile "com.netflix.spinnaker.moniker:moniker"
-  compile "com.squareup.retrofit:retrofit"
+  implementation "org.slf4j:jcl-over-slf4j"
+  implementation "com.netflix.spinnaker.kork:kork-core"
+  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "net.logstash.logback:logstash-logback-encoder"
+  implementation "com.netflix.spinnaker.moniker:moniker"
+  implementation "com.squareup.retrofit:retrofit"
+  implementation "com.fasterxml.jackson.core:jackson-annotations"
+  implementation "com.fasterxml.jackson.core:jackson-core"
+  implementation "com.fasterxml.jackson.core:jackson-databind"
+  implementation "com.squareup.retrofit:converter-jackson"
+  implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
+  implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
 
-  compile "com.fasterxml.jackson.core:jackson-annotations"
-  compile "com.fasterxml.jackson.core:jackson-core"
-  compile "com.fasterxml.jackson.core:jackson-databind"
-  compile "com.squareup.retrofit:converter-jackson"
-  compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
-  compile "com.fasterxml.jackson.module:jackson-module-kotlin"
-
-  testCompile project(":swabbie-test")
+  testImplementation project(":swabbie-test")
 }

--- a/swabbie-core/swabbie-core.gradle
+++ b/swabbie-core/swabbie-core.gradle
@@ -29,4 +29,5 @@ dependencies {
   implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
 
   testImplementation project(":swabbie-test")
+  testImplementation "com.netflix.spinnaker.kork:kork-test"
 }

--- a/swabbie-orca/swabbie-orca.gradle
+++ b/swabbie-orca/swabbie-orca.gradle
@@ -15,7 +15,8 @@
  */
 
 dependencies {
-  compile project(":swabbie-core")
-  compile project(":swabbie-retrofit")
-  compile "com.netflix.spinnaker.moniker:moniker"
+  implementation project(":swabbie-core")
+  implementation project(":swabbie-retrofit")
+  implementation "com.netflix.spinnaker.moniker:moniker"
+  implementation "net.logstash.logback:logstash-logback-encoder"
 }

--- a/swabbie-redis/swabbie-redis.gradle
+++ b/swabbie-redis/swabbie-redis.gradle
@@ -21,6 +21,7 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-jedis"
   implementation "com.netflix.spinnaker.kork:kork-dynomite"
   implementation "com.netflix.spinnaker.kork:kork-test"
+  implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
 
   testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"
   testImplementation project(":swabbie-test")

--- a/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/NoopCacheStatus.kt
+++ b/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/NoopCacheStatus.kt
@@ -1,18 +1,18 @@
 /*
  *
- *  * Copyright 2018 Netflix, Inc.
- *  *
- *  * Licensed under the Apache License, Version 2.0 (the "License")
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/NoopCacheStatus.kt
+++ b/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/NoopCacheStatus.kt
@@ -1,0 +1,25 @@
+/*
+ *
+ *  * Copyright 2018 Netflix, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License")
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.test
+
+import com.netflix.spinnaker.swabbie.CacheStatus
+
+class NoopCacheStatus : CacheStatus {
+  override fun cachesLoaded() = true
+}

--- a/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/WorkConfigurationTestHelper.kt
+++ b/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/WorkConfigurationTestHelper.kt
@@ -1,18 +1,18 @@
 /*
  *
- *  * Copyright 2018 Netflix, Inc.
- *  *
- *  * Licensed under the Apache License, Version 2.0 (the "License")
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 

--- a/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/WorkConfigurationTestHelper.kt
+++ b/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/WorkConfigurationTestHelper.kt
@@ -31,9 +31,10 @@ object WorkConfigurationTestHelper {
     itemsProcessedBatchSize: Int = 1,
     maxItemsProcessedPerCycle: Int = 10,
     retention: Int = 14,
-    notificationConfiguration: NotificationConfiguration = EmptyNotificationConfiguration()
+    notificationConfiguration: NotificationConfiguration = EmptyNotificationConfiguration(),
+    namespace: String = "$TEST_RESOURCE_PROVIDER_TYPE:test:us-east-1:$TEST_RESOURCE_TYPE"
   ): WorkConfiguration = WorkConfiguration(
-    namespace = "$TEST_RESOURCE_PROVIDER_TYPE:test:us-east-1:$TEST_RESOURCE_TYPE",
+    namespace = namespace,
     account = testAccount,
     location = "us-east-1",
     cloudProvider = TEST_RESOURCE_PROVIDER_TYPE,

--- a/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/WorkConfigurationTestHelper.kt
+++ b/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/WorkConfigurationTestHelper.kt
@@ -1,0 +1,59 @@
+/*
+ *
+ *  * Copyright 2018 Netflix, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License")
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.test
+
+import com.netflix.spinnaker.config.Exclusion
+import com.netflix.spinnaker.config.NotificationConfiguration
+import com.netflix.spinnaker.swabbie.model.EmptyNotificationConfiguration
+import com.netflix.spinnaker.swabbie.model.SpinnakerAccount
+import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+
+object WorkConfigurationTestHelper {
+  fun generateWorkConfiguration(
+    exclusions: List<Exclusion> = emptyList(),
+    dryRun: Boolean = false,
+    itemsProcessedBatchSize: Int = 1,
+    maxItemsProcessedPerCycle: Int = 10,
+    retention: Int = 14,
+    notificationConfiguration: NotificationConfiguration = EmptyNotificationConfiguration()
+  ): WorkConfiguration = WorkConfiguration(
+    namespace = "$TEST_RESOURCE_PROVIDER_TYPE:test:us-east-1:$TEST_RESOURCE_TYPE",
+    account = testAccount,
+    location = "us-east-1",
+    cloudProvider = TEST_RESOURCE_PROVIDER_TYPE,
+    resourceType = TEST_RESOURCE_TYPE,
+    retention = retention,
+    exclusions = exclusions.toSet(),
+    dryRun = dryRun,
+    maxAge = 1,
+    itemsProcessedBatchSize = itemsProcessedBatchSize,
+    maxItemsProcessedPerCycle = maxItemsProcessedPerCycle,
+    notificationConfiguration = notificationConfiguration
+  )
+
+  var testAccount = SpinnakerAccount(
+    name = "test",
+    accountId = "id",
+    type = "type",
+    edda = "",
+    regions = emptyList(),
+    eddaEnabled = false,
+    environment = "test"
+  )
+}

--- a/swabbie-test/swabbie-test.gradle
+++ b/swabbie-test/swabbie-test.gradle
@@ -1,4 +1,7 @@
 dependencies {
   api project(":swabbie-core")
   api "com.natpryce:hamkrest"
+  api "io.strikt:strikt-core"
+  implementation "org.slf4j:jcl-over-slf4j"
+  implementation "com.fasterxml.jackson.core:jackson-annotations"
 }


### PR DESCRIPTION
Swabbie was working when it was disabled in discovery. This PR fixes that functionality so that swabbie doesn't work when it's down in discovery, and also adds a test for that case.

I also added a testing util and refactored some of the tests.