### PR TITLE
fix(exclusion): Do not excluded expired resources

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -425,7 +425,12 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
     optedOutResourceStates: List<ResourceState>,
     action: Action
   ): Boolean {
-    if (resource.getViolations().any { summary -> summary.ruleName == AlwaysCleanRule::class.java.simpleName }) {
+    val hasAlwaysCleanRule = resource.getViolations()
+        .any { summary ->
+          summary.ruleName == AlwaysCleanRule::class.java.simpleName
+        }
+
+    if (hasAlwaysCleanRule && resource.expired(clock)) {
       return false
     }
 


### PR DESCRIPTION
- fixed to not expire if temporal tag has value "never"
- Updated to not exclude an expired resource