### PR TITLE
fix(core): Shuffle candidates before processing

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -230,9 +230,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
         .filter { it.markedResource.namespace == workConfiguration.namespace && it.optedOut }
 
       val preProcessedCandidates = candidates
-        .sortedBy {
-          it.createTs
-        }
+        .shuffled()
         .withResolvedOwners(workConfiguration)
         .also { preProcessCandidates(it, workConfiguration) }
         .filter { !shouldExcludeResource(it, workConfiguration, optedOutResourceStates, Action.MARK) }
@@ -486,9 +484,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
           candidate.resourceId == r.resourceId
         }
       }
-      .sortedBy {
-        it.createTs
-      }
+      .shuffled()
       .withResolvedOwners(workConfiguration)
       .also { preProcessCandidates(it, workConfiguration) }
 


### PR DESCRIPTION
- Shuffling candidates to give a semi equal chance for a candidate to be eval'd
- Sorting by createTs can result in the same subset of candidate to be eval'd
pver and over.