### PR TITLE
 removed the total resrouce number that used in notification. We logg…

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -116,7 +116,7 @@ abstract class AbstractResourceTypeHandler<T : Resource>(
 
     if (workConfiguration.notificationConfiguration.enabled) {
       // Notifications are routinely batched and sent by [com.netflix.spinnaker.swabbie.notifications.NotificationSender]
-      log.info("Queuing notifications for  ${markedResources.size} resources in ${workConfiguration.namespace}")
+      log.info("Queuing notifications for resources in ${workConfiguration.namespace}")
       notificationQueue.add(workConfiguration)
     } else {
       // Do not send notifications for these resources. They are updated with a new deletion timestamp to offset


### PR DESCRIPTION
…ed the processed resource number for marking, but logged totaly resource number of workconfiguration during notifying. This can cause confusion, so maybe we should remove the number that used in notification.