### PR TITLE
chore(*): Allow a placeholder account with the empty account

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Account.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Account.kt
@@ -58,14 +58,17 @@ data class SpinnakerAccount(
     get() = type
 }
 
+/**
+ * A placeholder account for things with no concept of an account
+ */
 data class EmptyAccount(
-  override val accountId: String? = "",
-  override val type: String = "",
-  override val name: String = "",
+  override val accountId: String? = none,
+  override val type: String = none,
+  override val name: String = none,
   override val eddaEnabled: Boolean = false,
-  override val edda: String? = "",
-  override val regions: List<Region> = emptyList(),
-  override val environment: String = "",
+  override val edda: String? = none,
+  override val regions: List<Region> = listOf(Region(false, none)),
+  override val environment: String = none,
   override val grouping: Grouping? = null
 ) : Account, HasDetails() {
   override val resourceId: String
@@ -75,3 +78,5 @@ data class EmptyAccount(
   override val cloudProvider: String
     get() = type
 }
+
+const val none = "none"

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
@@ -193,7 +193,7 @@ interface Identifiable : Named {
       values.any { it is String && this.patternMatched(it) || splitFieldValue.contains(it) }
   }
 
-  private fun <R : Any?> getProperty(propertyName: String): R {
+  fun <R : Any?> getProperty(propertyName: String): R {
     try {
       return readPropery(propertyName)
     } catch (e: NoSuchElementException) {

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/WorkConfiguratorTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/WorkConfiguratorTest.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.config.ExclusionType
 import com.netflix.spinnaker.config.ResourceTypeConfiguration
 import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.swabbie.exclusions.AccountExclusionPolicy
+import com.netflix.spinnaker.swabbie.model.EmptyAccount
 import com.netflix.spinnaker.swabbie.model.Region
 import com.netflix.spinnaker.swabbie.model.SpinnakerAccount
 import com.nhaarman.mockito_kotlin.doReturn
@@ -32,6 +33,9 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.contains
+import strikt.assertions.isEqualTo
 import java.util.Optional
 
 object WorkConfiguratorTest {
@@ -68,7 +72,9 @@ object WorkConfiguratorTest {
         )
       )
 
-    workConfigurator.getAccounts().size shouldMatch equalTo(2)
+    val accounts = workConfigurator.getAccounts()
+    expectThat(accounts.size).isEqualTo(3)
+    expectThat(accounts).contains(EmptyAccount())
   }
 
   @Test


### PR DESCRIPTION
- updated default values to empty account
- made Resource.getProperty public
- updated work configurator to account for the placeholder account