### PR TITLE
fix(notifications): Preventing resubmitting notifications

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/notifications/NotificationSender.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/notifications/NotificationSender.kt
@@ -64,7 +64,7 @@ class NotificationSender(
   private val notificationsQueueSizeId = registry.createId("swabbie.notifications.queueSize")
 
   private val lockOptions = LockManager.LockOptions()
-    .withLockName(lockingService.ownerName)
+    .withLockName(javaClass.simpleName)
     .withMaximumLockDuration(lockingService.swabbieMaxLockDuration)
 
   init {

--- a/swabbie-echo/src/main/kotlin/com/netflix/spinnaker/swabbie/echo/EchoNotifier.kt
+++ b/swabbie-echo/src/main/kotlin/com/netflix/spinnaker/swabbie/echo/EchoNotifier.kt
@@ -42,10 +42,11 @@ class EchoNotifier(
         when {
           notificationType.equals(NotificationType.EMAIL.name, true) -> {
             return try {
+              log.info("Sending notification to $recipient. context: $notificationContext")
               sendEmail(recipient, notificationContext)
               NotificationResult(recipient, NotificationType.EMAIL, success = true)
             } catch (e: Exception) {
-              log.error("Failed to send notification", e)
+              log.error("Failed to send notification to $recipient. context: $notificationContext", e)
               NotificationResult(recipient, NotificationType.EMAIL, success = false)
             }
           }

--- a/swabbie-echo/src/main/kotlin/com/netflix/spinnaker/swabbie/echo/EchoNotifier.kt
+++ b/swabbie-echo/src/main/kotlin/com/netflix/spinnaker/swabbie/echo/EchoNotifier.kt
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.swabbie.echo
 
 import com.netflix.spinnaker.config.NotificationConfiguration
-import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.swabbie.notifications.Notifier
 import com.netflix.spinnaker.swabbie.notifications.Notifier.NotificationResult
 import com.netflix.spinnaker.swabbie.notifications.Notifier.NotificationType
@@ -29,13 +28,9 @@ import java.lang.UnsupportedOperationException
 
 @Component
 class EchoNotifier(
-  private val echoService: EchoService,
-  private val retrySupport: RetrySupport
+  private val echoService: EchoService
 ) : Notifier {
   private val log: Logger = LoggerFactory.getLogger(javaClass)
-  private val timeoutMillis: Long = 5000
-  private val maxAttempts: Int = 3
-
   override fun notify(
     recipient: String,
     notificationContext: Map<String, Any>,
@@ -46,15 +41,12 @@ class EchoNotifier(
       .forEach { notificationType ->
         when {
           notificationType.equals(NotificationType.EMAIL.name, true) -> {
-            try {
-              retrySupport.retry({
-                sendEmail(recipient, notificationContext)
-              }, maxAttempts, timeoutMillis, false)
-
-              return NotificationResult(recipient, NotificationType.EMAIL, success = true)
+            return try {
+              sendEmail(recipient, notificationContext)
+              NotificationResult(recipient, NotificationType.EMAIL, success = true)
             } catch (e: Exception) {
               log.error("Failed to send notification", e)
-              return NotificationResult(recipient, NotificationType.EMAIL, success = false)
+              NotificationResult(recipient, NotificationType.EMAIL, success = false)
             }
           }
         }

--- a/swabbie-echo/src/test/kotlin/com/netflix/spinnaker/swabbie/echo/EchoNotifierTest.kt
+++ b/swabbie-echo/src/test/kotlin/com/netflix/spinnaker/swabbie/echo/EchoNotifierTest.kt
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.swabbie.echo
 
 import com.netflix.spinnaker.config.NotificationConfiguration
-import com.netflix.spinnaker.kork.core.RetrySupport
 import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.notifications.Notifier
@@ -32,7 +31,7 @@ import strikt.assertions.isEqualTo
 
 object EchoNotifierTest {
   private val echoService = mock<EchoService>()
-  private val subject = EchoNotifier(echoService, RetrySupport())
+  private val subject = EchoNotifier(echoService)
 
   @Test
   fun `should notify`() {


### PR DESCRIPTION
- remove retrySupport use from echo notifier
- only allow one worker to send notifications at a time