### PR TITLE
chore(java11): Compile with Java 11 (but targeting Java 8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle
@@ -27,4 +32,4 @@ jobs:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-        run: ./gradlew -PenablePublishing=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" build snapshot --stacktrace
+        run: ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" build snapshot --stacktrace

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,9 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    # Install Java 8 for cross-compilation support. Setting it up before
+    # Java 11 means it comes later in $PATH (because of how setup-java works)
     - uses: actions/setup-java@v1
       with:
         java-version: 8
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.gradle
@@ -19,4 +24,4 @@ jobs:
     - name: Build
       env:
         GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-      run: ./gradlew build javadoc
+      run: ./gradlew -PenableCrossCompilerPlugin=true build javadoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle
@@ -37,7 +42,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         run: |
-          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
+          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
       - name: Release build
         if: steps.release_info.outputs.IS_CANDIDATE == 'false'
         env:
@@ -45,7 +50,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         run: |
-          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
+          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Dates.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Dates.kt
@@ -28,6 +28,7 @@ class Dates {
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ"),
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"),
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"),
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"),
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"),
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"),
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ"),


### PR DESCRIPTION
Some additional changes:

* Added a new format to `Dates.kt` because the Java 11 JRE returns nanoseconds for `LocalDateTime.now()`, so a few tests were failing. Another option is to use `LocalDateTime.now().truncateTo(MILLIS)` but this seemed more future-proof to me. Let me know if you'd prefer a different fix, however.