### PR TITLE
chore(dependencies): manually bump spinnakerGradleVersion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
-#Mon Apr 06 22:57:50 UTC 2020
 enablePublishing=false
-spinnakerGradleVersion=7.0.2
 korkVersion=7.33.0
 org.gradle.parallel=true
+spinnakerGradleVersion=7.11.3

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
@@ -34,11 +34,11 @@ import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchConfigurationInMemor
 import com.netflix.spinnaker.swabbie.aws.caches.ImagesUsedByInstancesProvider
 import com.netflix.spinnaker.swabbie.aws.caches.LaunchConfigurationCacheProvider
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import java.time.Clock
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import java.time.Clock
 
 @Configuration
 @ComponentScan(basePackages = ["com.netflix.spinnaker.swabbie.aws"])

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/ExpiredResourceRule.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/ExpiredResourceRule.kt
@@ -22,8 +22,8 @@ import com.netflix.spinnaker.swabbie.model.Resource
 import com.netflix.spinnaker.swabbie.model.Result
 import com.netflix.spinnaker.swabbie.model.Rule
 import com.netflix.spinnaker.swabbie.model.Summary
-import org.springframework.stereotype.Component
 import java.time.Clock
+import org.springframework.stereotype.Component
 
 /**
  * This rule applies if this amazon resource has expired.

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroup.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroup.kt
@@ -18,14 +18,14 @@ package com.netflix.spinnaker.swabbie.aws.autoscalinggroups
 
 import com.amazonaws.services.autoscaling.model.SuspendedProcess
 import com.fasterxml.jackson.annotation.JsonTypeName
+import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer
 import com.netflix.spinnaker.swabbie.Dates
 import com.netflix.spinnaker.swabbie.aws.model.AmazonResource
 import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.SERVER_GROUP
+import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import java.lang.Exception
 import java.time.Instant
-import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer
-import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import java.time.LocalDateTime
 import java.time.ZoneId
 

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandler.kt
@@ -21,16 +21,16 @@ import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer
 import com.netflix.spinnaker.swabbie.AbstractResourceTypeHandler
-import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.ResourceOwnerResolver
 import com.netflix.spinnaker.swabbie.aws.AWS
+import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
 import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.MarkedResource
+import com.netflix.spinnaker.swabbie.model.ResourceState
 import com.netflix.spinnaker.swabbie.model.SERVER_GROUP
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
-import com.netflix.spinnaker.swabbie.model.ResourceState
 import com.netflix.spinnaker.swabbie.notifications.NotificationQueue
 import com.netflix.spinnaker.swabbie.notifications.Notifier
 import com.netflix.spinnaker.swabbie.orca.OrcaJob
@@ -43,10 +43,10 @@ import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.rules.RulesEngine
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
-import org.springframework.context.ApplicationEventPublisher
-import org.springframework.stereotype.Component
 import java.time.Clock
 import kotlin.system.measureTimeMillis
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
 
 @Component
 class AmazonAutoScalingGroupHandler(

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/Rules.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/Rules.kt
@@ -25,14 +25,14 @@ import com.netflix.spinnaker.swabbie.model.Resource
 import com.netflix.spinnaker.swabbie.model.Result
 import com.netflix.spinnaker.swabbie.model.Rule
 import com.netflix.spinnaker.swabbie.model.Summary
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.stereotype.Component
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import java.util.Optional
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
 
 @Component
 class ZeroInstanceDisabledServerGroupRule(

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/ImagesUsedByInstancesProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/ImagesUsedByInstancesProvider.kt
@@ -18,12 +18,12 @@ package com.netflix.spinnaker.swabbie.aws.caches
 
 import com.netflix.spinnaker.swabbie.AccountProvider
 import com.netflix.spinnaker.swabbie.CachedViewProvider
-import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.aws.AWS
+import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.aws.instances.AmazonInstance
+import java.time.Clock
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.time.Clock
 
 class ImagesUsedByInstancesProvider(
   private val clock: Clock,

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/LaunchConfigurationCacheProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/LaunchConfigurationCacheProvider.kt
@@ -18,14 +18,14 @@ package com.netflix.spinnaker.swabbie.aws.caches
 
 import com.netflix.spinnaker.swabbie.AccountProvider
 import com.netflix.spinnaker.swabbie.CachedViewProvider
-import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.aws.AWS
+import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.aws.launchconfigurations.AmazonLaunchConfiguration
 import com.netflix.spinnaker.swabbie.model.Account
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import java.time.Clock
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.time.Clock
 
 class LaunchConfigurationCacheProvider(
   private val clock: Clock,

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/exclusions/AmazonTagExclusionPolicy.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/exclusions/AmazonTagExclusionPolicy.kt
@@ -22,8 +22,8 @@ import com.netflix.spinnaker.swabbie.aws.model.AmazonResource
 import com.netflix.spinnaker.swabbie.exclusions.Excludable
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
 import com.netflix.spinnaker.swabbie.model.BasicTag
-import org.springframework.stereotype.Component
 import java.time.Clock
+import org.springframework.stereotype.Component
 
 @Component
 class AmazonTagExclusionPolicy(

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -51,13 +51,13 @@ import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.repository.UsedResourceRepository
 import com.netflix.spinnaker.swabbie.rules.RulesEngine
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
+import java.time.Clock
+import java.time.Duration
+import kotlin.system.measureTimeMillis
 import net.logstash.logback.argument.StructuredArguments.kv
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
-import java.time.Clock
-import java.time.Duration
-import kotlin.system.measureTimeMillis
 
 @Component
 class AmazonImageHandler(

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchconfigurations/AmazonLaunchConfigurationHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchconfigurations/AmazonLaunchConfigurationHandler.kt
@@ -34,17 +34,17 @@ import com.netflix.spinnaker.swabbie.notifications.Notifier
 import com.netflix.spinnaker.swabbie.orca.OrcaJob
 import com.netflix.spinnaker.swabbie.orca.OrcaService
 import com.netflix.spinnaker.swabbie.orca.OrchestrationRequest
+import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
+import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
+import com.netflix.spinnaker.swabbie.repository.ResourceUseTrackingRepository
 import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
-import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
-import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
-import com.netflix.spinnaker.swabbie.repository.ResourceUseTrackingRepository
 import com.netflix.spinnaker.swabbie.rules.RulesEngine
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
-import org.springframework.context.ApplicationEventPublisher
-import org.springframework.stereotype.Component
 import java.time.Clock
 import kotlin.system.measureTimeMillis
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
 
 @Component
 class AmazonLaunchConfigurationHandler(

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
@@ -20,9 +20,9 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.swabbie.AbstractResourceTypeHandler
-import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.ResourceOwnerResolver
 import com.netflix.spinnaker.swabbie.aws.AWS
+import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
 import com.netflix.spinnaker.swabbie.model.AWS
@@ -41,9 +41,9 @@ import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.rules.RulesEngine
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
+import java.time.Clock
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
-import java.time.Clock
 
 @Component
 class AmazonLoadBalancerHandler(

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
@@ -20,14 +20,14 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.swabbie.AbstractResourceTypeHandler
-import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.ResourceOwnerResolver
 import com.netflix.spinnaker.swabbie.aws.AWS
+import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
+import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.SECURITY_GROUP
-import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.notifications.NotificationQueue
 import com.netflix.spinnaker.swabbie.notifications.Notifier
@@ -41,9 +41,9 @@ import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.rules.RulesEngine
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
+import java.time.Clock
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
-import java.time.Clock
 
 @Component
 class AmazonSecurityGroupHandler(

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshot.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshot.kt
@@ -19,10 +19,10 @@
 package com.netflix.spinnaker.swabbie.aws.snapshots
 
 import com.fasterxml.jackson.annotation.JsonTypeName
+import com.netflix.spinnaker.swabbie.Dates
 import com.netflix.spinnaker.swabbie.aws.model.AmazonResource
 import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.SNAPSHOT
-import com.netflix.spinnaker.swabbie.Dates
 import java.time.Instant
 import java.time.ZoneId
 

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandler.kt
@@ -22,9 +22,9 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.swabbie.AbstractResourceTypeHandler
-import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.ResourceOwnerResolver
 import com.netflix.spinnaker.swabbie.aws.AWS
+import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
 import com.netflix.spinnaker.swabbie.model.AWS
@@ -45,10 +45,10 @@ import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.repository.UsedResourceRepository
 import com.netflix.spinnaker.swabbie.rules.RulesEngine
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
+import java.time.Clock
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
-import java.time.Clock
 
 @Component
 class AmazonSnapshotHandler(

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/ExpiredResourceRuleTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/ExpiredResourceRuleTest.kt
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.swabbie.aws
 
 import com.netflix.spinnaker.kork.test.time.MutableClock
 import com.netflix.spinnaker.swabbie.aws.autoscalinggroups.AmazonAutoScalingGroup
+import java.time.Duration
+import java.time.Instant
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
-import java.time.Duration
-import java.time.Instant
 
 object ExpiredResourceRuleTest {
   private val clock = MutableClock()

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandlerTest.kt
@@ -24,12 +24,12 @@ import com.netflix.spinnaker.swabbie.aws.AWS
 import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.events.DeleteResourceEvent
 import com.netflix.spinnaker.swabbie.events.MarkResourceEvent
+import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.NotificationInfo
-import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.model.Rule
 import com.netflix.spinnaker.swabbie.model.SERVER_GROUP
-import com.netflix.spinnaker.swabbie.model.AWS
+import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.notifications.NotificationQueue
 import com.netflix.spinnaker.swabbie.orca.OrcaExecutionStatus
 import com.netflix.spinnaker.swabbie.orca.OrcaService
@@ -48,10 +48,13 @@ import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.validateMockitoUsage
 import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -60,9 +63,6 @@ import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isTrue
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 
 object AmazonAutoScalingGroupHandlerTest {
   private val aws = mock<AWS>()

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/DisabledLoadBalancerRuleTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/DisabledLoadBalancerRuleTest.kt
@@ -19,12 +19,12 @@ package com.netflix.spinnaker.swabbie.aws.autoscalinggroups
 import com.amazonaws.services.autoscaling.model.SuspendedProcess
 import com.netflix.spinnaker.config.ResourceTypeConfiguration.RuleDefinition
 import com.netflix.spinnaker.kork.test.time.MutableClock
+import java.time.Duration
+import java.time.LocalDateTime
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
-import java.time.Duration
-import java.time.LocalDateTime
 
 object DisabledLoadBalancerRuleTest {
   private val clock = MutableClock()

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/NotInDiscoveryRuleTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/NotInDiscoveryRuleTest.kt
@@ -22,15 +22,15 @@ import com.netflix.spinnaker.config.ResourceTypeConfiguration.RuleDefinition
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
-import org.junit.jupiter.api.Test
-import strikt.api.expectThat
-import strikt.assertions.isNotNull
-import strikt.assertions.isNull
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.Optional
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
 
 object NotInDiscoveryRuleTest {
   private val clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/ZeroInstanceDisabledServerGroupRuleTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/ZeroInstanceDisabledServerGroupRuleTest.kt
@@ -17,12 +17,12 @@
 package com.netflix.spinnaker.swabbie.aws.autoscalinggroups
 
 import com.amazonaws.services.autoscaling.model.SuspendedProcess
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
 
 object ZeroInstanceDisabledServerGroupRuleTest {
 

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/ZeroInstanceInDiscoveryDisabledServerGroupRuleTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/ZeroInstanceInDiscoveryDisabledServerGroupRuleTest.kt
@@ -23,15 +23,15 @@ import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
-import org.junit.jupiter.api.Test
-import strikt.api.expectThat
-import strikt.assertions.isNotNull
-import strikt.assertions.isNull
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.Optional
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
 
 object ZeroInstanceInDiscoveryDisabledServerGroupRuleTest {
 

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/ZeroInstanceRuleTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/ZeroInstanceRuleTest.kt
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.swabbie.aws.autoscalinggroups
 
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 
 object ZeroInstanceRuleTest {
   private val clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/ZeroLoadBalancerRuleTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/ZeroLoadBalancerRuleTest.kt
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.swabbie.aws.autoscalinggroups
 
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 
 object ZeroLoadBalancerRuleTest {
   private val clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/exclusions/AmazonTagExclusionPolicyTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/exclusions/AmazonTagExclusionPolicyTest.kt
@@ -24,11 +24,11 @@ import com.netflix.spinnaker.config.Exclusion
 import com.netflix.spinnaker.config.ExclusionType
 import com.netflix.spinnaker.kork.test.time.MutableClock
 import com.netflix.spinnaker.swabbie.aws.model.AmazonResource
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 object AmazonTagExclusionPolicyTest {
   private val clock = MutableClock()

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
@@ -20,8 +20,8 @@ import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.swabbie.InMemorySingletonCache
 import com.netflix.spinnaker.swabbie.ResourceOwnerResolver
-import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.aws.AWS
+import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.aws.caches.AmazonImagesUsedByInstancesCache
 import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchConfigurationCache
 import com.netflix.spinnaker.swabbie.events.DeleteResourceEvent
@@ -52,6 +52,10 @@ import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -64,10 +68,6 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isNull
 import strikt.assertions.isTrue
-import java.time.Clock
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneOffset
 
 object AmazonImageHandlerTest {
   private val resourceRepository = mock<ResourceTrackingRepository>()

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/launchconfigurations/AmazonLaunchConfigurationHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/launchconfigurations/AmazonLaunchConfigurationHandlerTest.kt
@@ -27,10 +27,10 @@ import com.netflix.spinnaker.swabbie.aws.launchconfigurations.AmazonLaunchConfig
 import com.netflix.spinnaker.swabbie.events.DeleteResourceEvent
 import com.netflix.spinnaker.swabbie.events.MarkResourceEvent
 import com.netflix.spinnaker.swabbie.model.AWS
-import com.netflix.spinnaker.swabbie.model.Rule
 import com.netflix.spinnaker.swabbie.model.LAUNCH_CONFIGURATION
 import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.NotificationInfo
+import com.netflix.spinnaker.swabbie.model.Rule
 import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.notifications.NotificationQueue
 import com.netflix.spinnaker.swabbie.orca.OrcaService
@@ -42,28 +42,28 @@ import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.rules.ResourceRulesEngine
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
-import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.reset
+import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.validateMockitoUsage
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.times
+import com.nhaarman.mockito_kotlin.whenever
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
-import strikt.assertions.isTrue
-import strikt.assertions.isFalse
 import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
 import strikt.assertions.isNull
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
+import strikt.assertions.isTrue
 
 object AmazonLaunchConfigurationHandlerTest {
   private val aws = mock<AWS>()

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandlerTest.kt
@@ -25,14 +25,14 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
-import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.ResourceOwnerResolver
 import com.netflix.spinnaker.swabbie.aws.AWS
+import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.aws.images.AmazonImage
 import com.netflix.spinnaker.swabbie.events.MarkResourceEvent
-import com.netflix.spinnaker.swabbie.model.SNAPSHOT
 import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.Rule
+import com.netflix.spinnaker.swabbie.model.SNAPSHOT
 import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.notifications.NotificationQueue
 import com.netflix.spinnaker.swabbie.orca.OrcaService
@@ -45,16 +45,19 @@ import com.netflix.spinnaker.swabbie.rules.ResourceRulesEngine
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
 import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.validateMockitoUsage
-import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.doThrow
 import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.times
+import com.nhaarman.mockito_kotlin.validateMockitoUsage
 import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
 import com.nhaarman.mockito_kotlin.whenever
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -65,9 +68,6 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isNull
 import strikt.assertions.isTrue
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 
 object AmazonSnapshotHandlerTest {
   private val objectMapper = ObjectMapper().registerKotlinModule().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieConfiguration.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieConfiguration.kt
@@ -36,6 +36,8 @@ import com.netflix.spinnaker.swabbie.exclusions.ExclusionsSupplier
 import com.netflix.spinnaker.swabbie.model.RESOURCE_TYPE_INFO_FIELD
 import com.netflix.spinnaker.swabbie.model.Resource
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import java.time.Clock
+import java.util.Optional
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -46,8 +48,6 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.type.filter.AssignableTypeFilter
 import org.springframework.util.ClassUtils
-import java.time.Clock
-import java.util.Optional
 
 @Configuration
 @EnableConfigurationProperties(SwabbieProperties::class)

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.config
 
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.model.EmptyNotificationConfiguration
-import org.springframework.boot.context.properties.ConfigurationProperties
 import java.time.DayOfWeek
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneId
+import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
  * @param {@link #minImagesUsedByLC} minimum number of images used by launch configurations that should be

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/AbstractResourceTypeHandler.kt
@@ -45,9 +45,6 @@ import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
 import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
 import com.netflix.spinnaker.swabbie.repository.ResourceUseTrackingRepository
 import com.netflix.spinnaker.swabbie.rules.RulesEngine
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import org.springframework.context.ApplicationEventPublisher
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -56,6 +53,9 @@ import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.min
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
 
 abstract class AbstractResourceTypeHandler<T : Resource>(
   private val registry: Registry,

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CacheStatus.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/CacheStatus.kt
@@ -1,11 +1,11 @@
 package com.netflix.spinnaker.swabbie
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Component
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
 
 interface CacheStatus {
   abstract fun cachesLoaded(): Boolean

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Cacheable.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Cacheable.kt
@@ -17,10 +17,10 @@
 package com.netflix.spinnaker.swabbie
 
 import com.netflix.spinnaker.swabbie.model.Named
+import java.util.concurrent.atomic.AtomicReference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
-import java.util.concurrent.atomic.AtomicReference
 
 interface Cacheable : Named
 

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/LockingService.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/LockingService.kt
@@ -18,10 +18,10 @@ package com.netflix.spinnaker.swabbie
 
 import com.netflix.spinnaker.config.LockingConfigurationProperties
 import com.netflix.spinnaker.kork.lock.LockManager
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.concurrent.Callable
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 open class LockingService(
   private val lockManager: LockManager,

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceOwnerResolver.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceOwnerResolver.kt
@@ -18,10 +18,10 @@ package com.netflix.spinnaker.swabbie
 
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.swabbie.model.Resource
+import java.util.regex.Pattern
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.util.regex.Pattern
 
 /**
  * Looks at all available resolution strategies for finding an owner for a resource,

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandler.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandler.kt
@@ -18,9 +18,9 @@ package com.netflix.spinnaker.swabbie
 
 import com.netflix.spinnaker.swabbie.model.OnDemandMarkData
 import com.netflix.spinnaker.swabbie.model.Resource
-import com.netflix.spinnaker.swabbie.model.Summary
-import com.netflix.spinnaker.swabbie.model.ResourceState
 import com.netflix.spinnaker.swabbie.model.ResourceEvaluation
+import com.netflix.spinnaker.swabbie.model.ResourceState
+import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 
 interface ResourceTypeHandler<T : Resource> {

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/WorkConfigurator.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/WorkConfigurator.kt
@@ -26,9 +26,9 @@ import com.netflix.spinnaker.swabbie.exclusions.shouldExclude
 import com.netflix.spinnaker.swabbie.model.Account
 import com.netflix.spinnaker.swabbie.model.EmptyAccount
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import java.util.Optional
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.Optional
 
 /**
  * Flattens the YAML configuration into units of work called [WorkConfiguration]

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/discovery/DiscoveryActivated.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/discovery/DiscoveryActivated.kt
@@ -2,9 +2,9 @@ package com.netflix.spinnaker.swabbie.discovery
 
 import com.netflix.appinfo.InstanceInfo
 import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
+import java.util.concurrent.atomic.AtomicBoolean
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationListener
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * A component that starts doing something when the instance is up in discovery

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/discovery/DiscoveryPollingConfiguration.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/discovery/DiscoveryPollingConfiguration.kt
@@ -17,11 +17,11 @@
 package com.netflix.spinnaker.swabbie.discovery
 
 import com.netflix.discovery.EurekaClient
+import java.lang.management.ManagementFactory
+import java.util.Optional
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import java.lang.management.ManagementFactory
-import java.util.Optional
 
 @Configuration
 open class DiscoveryPollingConfiguration {

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManager.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManager.kt
@@ -24,11 +24,11 @@ import com.netflix.spinnaker.swabbie.model.Status
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
 import com.netflix.spinnaker.swabbie.tagging.ResourceTagger
+import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
-import java.time.Clock
 
 @Component
 class ResourceStateManager(

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
@@ -24,14 +24,14 @@ import com.netflix.spinnaker.swabbie.exclusions.Excludable
 import com.netflix.spinnaker.swabbie.notifications.Notifier
 import com.netflix.spinnaker.swabbie.repository.LastSeenInfo
 import com.netflix.spinnaker.swabbie.tagging.TemporalTags
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.util.NoSuchElementException
 import kotlin.reflect.full.memberProperties
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 /** Resource Types **/
 const val SECURITY_GROUP = "securityGroup"

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/notifications/NotificationSender.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/notifications/NotificationSender.kt
@@ -26,21 +26,21 @@ import com.netflix.spinnaker.swabbie.discovery.DiscoveryActivated
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.events.OwnerNotifiedEvent
 import com.netflix.spinnaker.swabbie.model.MarkedResource
-import com.netflix.spinnaker.swabbie.model.ResourceState
 import com.netflix.spinnaker.swabbie.model.NotificationInfo
+import com.netflix.spinnaker.swabbie.model.ResourceState
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.notifications.Notifier.NotificationResult
 import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
 import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
+import java.time.Clock
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.time.Clock
-import java.time.Instant
-import java.time.temporal.ChronoUnit
 
 /**
  * A scheduled notification sender

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/InMemoryTaskTrackingRepository.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/InMemoryTaskTrackingRepository.kt
@@ -18,9 +18,9 @@
 
 package com.netflix.spinnaker.swabbie.repository
 
-import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.util.concurrent.TimeUnit
+import org.slf4j.LoggerFactory
 
 class InMemoryTaskTrackingRepository(
   private val clock: Clock

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/rules/Rules.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/rules/Rules.kt
@@ -21,8 +21,8 @@ import com.netflix.spinnaker.swabbie.model.Resource
 import com.netflix.spinnaker.swabbie.model.Result
 import com.netflix.spinnaker.swabbie.model.Rule
 import com.netflix.spinnaker.swabbie.model.Summary
-import org.springframework.stereotype.Component
 import java.time.Clock
+import org.springframework.stereotype.Component
 
 @Component
 class AgeRule(

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/tagging/ResourceEntityTagger.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/tagging/ResourceEntityTagger.kt
@@ -19,10 +19,10 @@ package com.netflix.spinnaker.swabbie.tagging
 import com.netflix.spinnaker.moniker.frigga.FriggaReflectiveNamer
 import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import java.time.Clock
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.time.Clock
 
 @Component
 class ResourceEntityTagger(

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/work/WorkProcessor.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/work/WorkProcessor.kt
@@ -24,14 +24,14 @@ import com.netflix.spinnaker.swabbie.ResourceTypeHandler
 import com.netflix.spinnaker.swabbie.discovery.DiscoveryActivated
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.model.WorkItem
+import java.time.Clock
+import java.util.concurrent.TimeUnit
+import kotlin.system.measureTimeMillis
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.time.Clock
-import java.util.concurrent.TimeUnit
-import kotlin.system.measureTimeMillis
 
 @Component
 @ConditionalOnExpression("\${swabbie.enabled:true}")

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManager.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManager.kt
@@ -24,16 +24,16 @@ import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.eureka.RemoteStatusChangedEvent
 import com.netflix.spinnaker.swabbie.CacheStatus
 import com.netflix.spinnaker.swabbie.discovery.DiscoveryActivated
+import java.lang.IllegalStateException
+import java.time.Clock
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.lang.IllegalStateException
-import java.time.Clock
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.Duration
 
 /**
  * Serves as the producer of work for resource handlers, monitors and refills the work queue once all work is complete

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
@@ -30,7 +30,6 @@ import com.netflix.spinnaker.swabbie.model.NotificationInfo
 import com.netflix.spinnaker.swabbie.model.ResourceState
 import com.netflix.spinnaker.swabbie.model.Status
 import com.netflix.spinnaker.swabbie.model.Summary
-import com.netflix.spinnaker.swabbie.test.TEST_RESOURCE_PROVIDER_TYPE
 import com.netflix.spinnaker.swabbie.notifications.Notifier
 import com.netflix.spinnaker.swabbie.notifications.Notifier.NotificationResult
 import com.netflix.spinnaker.swabbie.notifications.Notifier.NotificationType.EMAIL
@@ -40,10 +39,12 @@ import com.netflix.spinnaker.swabbie.repository.ResourceUseTrackingRepository
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.rules.RulesEngine
 import com.netflix.spinnaker.swabbie.test.InMemoryNotificationQueue
+import com.netflix.spinnaker.swabbie.test.TEST_RESOURCE_PROVIDER_TYPE
 import com.netflix.spinnaker.swabbie.test.TEST_RESOURCE_TYPE
 import com.netflix.spinnaker.swabbie.test.TestResource
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argWhere
 import com.nhaarman.mockito_kotlin.check
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.inOrder
@@ -53,7 +54,11 @@ import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
-import com.nhaarman.mockito_kotlin.argWhere
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -61,15 +66,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
-import strikt.assertions.isFalse
 import strikt.assertions.isTrue
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
-import java.time.temporal.ChronoUnit
-import java.util.concurrent.TimeUnit
 
 object ResourceTypeHandlerTest {
   private val resourceRepository = mock<ResourceTrackingRepository>()

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ScheduleTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ScheduleTest.kt
@@ -21,8 +21,8 @@ package com.netflix.spinnaker.swabbie
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.should.shouldMatch
 import com.netflix.spinnaker.config.Schedule
-import org.junit.jupiter.api.Test
 import java.time.Instant
+import org.junit.jupiter.api.Test
 
 object ScheduleTest {
   private val subject = Schedule().also { it.enabled = true }

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/TestResourceTypeHandler.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/TestResourceTypeHandler.kt
@@ -41,8 +41,8 @@ import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.rules.RulesEngine
 import com.netflix.spinnaker.swabbie.test.TestResource
-import org.springframework.context.ApplicationEventPublisher
 import java.time.Clock
+import org.springframework.context.ApplicationEventPublisher
 
 /**
  * A test resource type handler that provides fake resources to test abstract resource type handler logic

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/WorkConfiguratorTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/WorkConfiguratorTest.kt
@@ -31,12 +31,12 @@ import com.netflix.spinnaker.swabbie.model.SpinnakerAccount
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
+import java.util.Optional
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.contains
 import strikt.assertions.isEqualTo
-import java.util.Optional
 
 object WorkConfiguratorTest {
   private val accountProvider: AccountProvider = mock()

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManagerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManagerTest.kt
@@ -32,11 +32,11 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Test
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
 
 object ResourceStateManagerTest {
   private val resourceStateRepository = mock<ResourceStateRepository>()

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceTrackingManagerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceTrackingManagerTest.kt
@@ -28,9 +28,9 @@ import com.nhaarman.mockito_kotlin.argWhere
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
+import java.time.Clock
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import java.time.Clock
 
 object ResourceTrackingManagerTest {
   private val resourceTrackingRepository = mock<ResourceTrackingRepository>()

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/notifications/NotificationSenderTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/notifications/NotificationSenderTest.kt
@@ -25,24 +25,25 @@ import com.netflix.spinnaker.swabbie.LockingService
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.events.OwnerNotifiedEvent
 import com.netflix.spinnaker.swabbie.model.MarkedResource
-import com.netflix.spinnaker.swabbie.model.Summary
-import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.model.ResourceState
 import com.netflix.spinnaker.swabbie.model.Status
-import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
+import com.netflix.spinnaker.swabbie.model.Summary
+import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
+import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
 import com.netflix.spinnaker.swabbie.test.InMemoryNotificationQueue
 import com.netflix.spinnaker.swabbie.test.TestResource
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.whenever
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.times
-
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import java.time.Clock
+import java.time.Instant
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -51,8 +52,6 @@ import strikt.api.expectThat
 import strikt.assertions.isNotEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
-import java.time.Clock
-import java.time.Instant
 
 object NotificationSenderTest {
   private val notifier = mock<Notifier>()

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/rules/AgeRuleTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/rules/AgeRuleTest.kt
@@ -18,14 +18,14 @@ package com.netflix.spinnaker.swabbie.rules
 
 import com.netflix.spinnaker.config.ResourceTypeConfiguration.RuleDefinition
 import com.netflix.spinnaker.swabbie.test.TestResource
-import org.junit.jupiter.api.Test
-import strikt.api.expectThat
-import strikt.assertions.isNotNull
-import strikt.assertions.isNull
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
 
 object AgeRuleTest {
   private val clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/rules/AttributeRuleTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/rules/AttributeRuleTest.kt
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.swabbie.rules
 
 import com.netflix.spinnaker.config.ResourceTypeConfiguration.RuleDefinition
 import com.netflix.spinnaker.swabbie.test.TestResource
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 
 object AttributeRuleTest {
   private val clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/rules/RulesEngineTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/rules/RulesEngineTest.kt
@@ -27,15 +27,15 @@ import com.netflix.spinnaker.swabbie.test.TEST_RESOURCE_PROVIDER_TYPE
 import com.netflix.spinnaker.swabbie.test.TEST_RESOURCE_TYPE
 import com.netflix.spinnaker.swabbie.test.TestResource
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
-import org.junit.jupiter.api.Test
-import strikt.api.expectThat
-import strikt.assertions.isEmpty
-import strikt.assertions.containsExactlyInAnyOrder
-import strikt.assertions.containsExactly
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+import strikt.assertions.containsExactlyInAnyOrder
+import strikt.assertions.isEmpty
 
 object RulesEngineTest {
   private val clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkProcessorTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkProcessorTest.kt
@@ -35,12 +35,12 @@ import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
+import java.time.Clock
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isFalse
 import strikt.assertions.isTrue
-import java.time.Clock
 
 object WorkProcessorTest {
   private val workConfiguration1 = WorkConfigurationTestHelper

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManagerScheduleTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManagerScheduleTest.kt
@@ -19,11 +19,6 @@
 package com.netflix.spinnaker.swabbie.work
 
 import com.netflix.spinnaker.config.Schedule
-import org.junit.jupiter.api.Test
-import strikt.api.expectThat
-import strikt.api.expectThrows
-import strikt.assertions.isFalse
-import strikt.assertions.isTrue
 import java.time.Clock
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -31,6 +26,11 @@ import java.time.LocalDateTime
 import java.time.Month
 import java.time.ZoneId
 import java.time.ZoneOffset
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.api.expectThrows
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
 
 object WorkQueueManagerScheduleTest {
 

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManagerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManagerTest.kt
@@ -31,16 +31,16 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.whenever
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import strikt.api.expectThat
-import strikt.assertions.isFalse
-import strikt.assertions.isTrue
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.Month
 import java.time.ZoneId
 import java.time.ZoneOffset
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
 
 object WorkQueueManagerTest {
 

--- a/swabbie-echo/src/main/kotlin/com/netflix/spinnaker/swabbie/echo/EchoNotifier.kt
+++ b/swabbie-echo/src/main/kotlin/com/netflix/spinnaker/swabbie/echo/EchoNotifier.kt
@@ -19,12 +19,12 @@ package com.netflix.spinnaker.swabbie.echo
 import com.netflix.spinnaker.config.NotificationConfiguration
 import com.netflix.spinnaker.swabbie.notifications.Notifier
 import com.netflix.spinnaker.swabbie.notifications.Notifier.NotificationResult
-import com.netflix.spinnaker.swabbie.notifications.Notifier.NotificationType
 import com.netflix.spinnaker.swabbie.notifications.Notifier.NotificationSeverity
+import com.netflix.spinnaker.swabbie.notifications.Notifier.NotificationType
+import java.lang.UnsupportedOperationException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.lang.UnsupportedOperationException
 
 @Component
 class EchoNotifier(

--- a/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaTaskMonitoringAgent.kt
+++ b/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaTaskMonitoringAgent.kt
@@ -27,12 +27,6 @@ import com.netflix.spinnaker.swabbie.LockingService
 import com.netflix.spinnaker.swabbie.discovery.DiscoveryActivated
 import com.netflix.spinnaker.swabbie.events.OrcaTaskFailureEvent
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
-import net.logstash.logback.argument.StructuredArguments.kv
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.context.ApplicationEventPublisher
-import org.springframework.stereotype.Component
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -43,6 +37,12 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import javax.annotation.PostConstruct
 import javax.annotation.PreDestroy
+import net.logstash.logback.argument.StructuredArguments.kv
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
 
 @Component
 class OrcaTaskMonitoringAgent(

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/LockingConfiguration.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/LockingConfiguration.kt
@@ -23,13 +23,13 @@ import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.kork.jedis.lock.RedisLockManager
 import com.netflix.spinnaker.kork.lock.LockManager
 import com.netflix.spinnaker.swabbie.LockingService
+import java.time.Clock
+import java.util.Optional
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import java.time.Clock
-import java.util.Optional
 
 @Configuration
 @EnableConfigurationProperties(LockingConfigurationProperties::class)

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisNotificationQueue.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisNotificationQueue.kt
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.swabbie.redis
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.swabbie.notifications.NotificationQueue

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceStateRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceStateRepository.kt
@@ -24,13 +24,13 @@ import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.swabbie.model.ResourceState
 import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
+import java.time.Clock
+import java.util.concurrent.TimeUnit
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import redis.clients.jedis.ScanParams
-import java.time.Clock
-import java.util.concurrent.TimeUnit
 
 @Component
 class RedisResourceStateRepository(

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceTrackingRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceTrackingRepository.kt
@@ -25,13 +25,13 @@ import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.repository.DeleteInfo
 import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
+import java.time.Clock
+import java.time.Instant
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import redis.clients.jedis.ScanParams
 import redis.clients.jedis.ScanResult
 import redis.clients.jedis.Tuple
-import java.time.Clock
-import java.time.Instant
 
 @Component
 class RedisResourceTrackingRepository(

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceUseTrackingRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceUseTrackingRepository.kt
@@ -27,14 +27,14 @@ import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.swabbie.repository.LastSeenInfo
 import com.netflix.spinnaker.swabbie.repository.ResourceUseTrackingRepository
+import java.time.Clock
+import java.time.Duration
+import java.time.temporal.ChronoUnit
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import redis.clients.jedis.ScanParams
 import redis.clients.jedis.ScanResult
 import redis.clients.jedis.Tuple
-import java.time.Clock
-import java.time.Duration
-import java.time.temporal.ChronoUnit
 
 @Component
 class RedisResourceUseTrackingRepository(

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisTaskTrackingRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisTaskTrackingRepository.kt
@@ -26,13 +26,13 @@ import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
 import com.netflix.spinnaker.swabbie.repository.TaskState
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
+import java.time.Clock
+import java.util.concurrent.TimeUnit
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import redis.clients.jedis.ScanParams
 import redis.clients.jedis.ScanResult
-import java.time.Clock
-import java.util.concurrent.TimeUnit
 
 @Component
 class RedisTaskTrackingRepository(

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisUsedResourceRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisUsedResourceRepository.kt
@@ -21,10 +21,10 @@ package com.netflix.spinnaker.swabbie.redis
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.swabbie.repository.UsedResourceRepository
+import java.util.concurrent.TimeUnit
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import java.util.concurrent.TimeUnit
 
 @Component
 class RedisUsedResourceRepository(

--- a/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceStateRepositoryTest.kt
+++ b/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceStateRepositoryTest.kt
@@ -33,6 +33,8 @@ import com.netflix.spinnaker.swabbie.model.ResourceState
 import com.netflix.spinnaker.swabbie.model.Status
 import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.test.TestResource
+import java.time.Duration
+import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -41,8 +43,6 @@ import redis.clients.jedis.JedisPool
 import strikt.api.expect
 import strikt.assertions.hasSize
 import strikt.assertions.isNotNull
-import java.time.Duration
-import java.util.concurrent.TimeUnit
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 object RedisResourceStateRepositoryTest {

--- a/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceTrackingRepositoryTest.kt
+++ b/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceTrackingRepositoryTest.kt
@@ -34,6 +34,10 @@ import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.repository.DeleteInfo
 import com.netflix.spinnaker.swabbie.test.TestResource
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -41,10 +45,6 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.springframework.util.Assert
 import redis.clients.jedis.JedisPool
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
-import java.time.temporal.ChronoUnit
 
 @TestInstance(Lifecycle.PER_CLASS)
 object RedisResourceTrackingRepositoryTest {

--- a/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceUseTrackingRepositoryTest.kt
+++ b/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisResourceUseTrackingRepositoryTest.kt
@@ -29,13 +29,13 @@ import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientSelector
 import com.netflix.spinnaker.kork.test.time.MutableClock
 import com.netflix.spinnaker.swabbie.test.TestResource
+import java.time.Duration
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.util.Assert
 import redis.clients.jedis.JedisPool
-import java.time.Duration
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 object RedisResourceUseTrackingRepositoryTest {

--- a/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisTaskTrackingRepositoryTest.kt
+++ b/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisTaskTrackingRepositoryTest.kt
@@ -34,15 +34,15 @@ import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.repository.TaskCompleteEventInfo
 import com.netflix.spinnaker.swabbie.test.TestResource
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.util.Assert
 import redis.clients.jedis.JedisPool
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 object RedisTaskTrackingRepositoryTest {

--- a/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/InMemoryWorkQueue.kt
+++ b/swabbie-test/src/main/kotlin/com/netflix/spinnaker/swabbie/test/InMemoryWorkQueue.kt
@@ -19,8 +19,8 @@ package com.netflix.spinnaker.swabbie.test
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.model.WorkItem
 import com.netflix.spinnaker.swabbie.work.WorkQueue
-import org.slf4j.LoggerFactory
 import java.util.concurrent.LinkedBlockingQueue
+import org.slf4j.LoggerFactory
 
 // For testing purpose
 class InMemoryWorkQueue(

--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/ResourceController.kt
@@ -22,8 +22,8 @@ import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.MarkedResourceInterface
 import com.netflix.spinnaker.swabbie.model.ResourceEvaluation
 import com.netflix.spinnaker.swabbie.model.ResourceState
-import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.model.SwabbieNamespace
+import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.notifications.NotificationSender
 import com.netflix.spinnaker.swabbie.repository.DeleteInfo
 import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository

--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/TestingController.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/controllers/TestingController.kt
@@ -27,13 +27,13 @@ import com.netflix.spinnaker.swabbie.model.SwabbieNamespace
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.notifications.NotificationSender
 import com.netflix.spinnaker.swabbie.test.TestResource
+import java.time.Clock
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
-import java.time.Clock
 
 /**
  * This controller is for testing resources by on demand marking and deleting them.

--- a/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/web/config/WebConfiguration.kt
+++ b/swabbie-web/src/main/kotlin/com/netflix/spinnaker/swabbie/web/config/WebConfiguration.kt
@@ -19,6 +19,12 @@ package com.netflix.spinnaker.swabbie.web.config
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.FilterConfig
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
@@ -27,12 +33,6 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
-import javax.servlet.Filter
-import javax.servlet.FilterChain
-import javax.servlet.FilterConfig
-import javax.servlet.ServletRequest
-import javax.servlet.ServletResponse
-import javax.servlet.http.HttpServletResponse
 
 @Configuration
 @ComponentScan(basePackages = arrayOf(


### PR DESCRIPTION
This required reformatting a lot of kotlin imports to go with the new spotless version.

Replaces #397.