### PR TITLE
chore(dependencies): Add explicit dependency

### DIFF
--- a/swabbie-core/swabbie-core.gradle
+++ b/swabbie-core/swabbie-core.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
   implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
+  implementation "com.google.guava:guava"
 
   testImplementation project(":swabbie-test")
   testImplementation "com.netflix.spinnaker.kork:kork-test"


### PR DESCRIPTION
An upcoming kork bump changes a number of dependencies from api to implementation when comsumers shouldn't need these on the compile path. This commit explicitly adds in dependencies that will no longer be transitively included.