### PR TITLE
[Do Not Merge] fix(aws): Do not cache accounts which are not part of the workConfigurations

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
@@ -58,7 +58,7 @@ open class AwsConfiguration {
     accountProvider: AccountProvider,
     aws: AWS
   ): CachedViewProvider<AmazonImagesUsedByInstancesCache> {
-    return ImagesUsedByInstancesProvider(clock, accountProvider, aws)
+    return ImagesUsedByInstancesProvider(clock, workConfigurations, accountProvider, aws)
   }
 
   @Bean

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/LaunchConfigurationCacheProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/LaunchConfigurationCacheProvider.kt
@@ -40,8 +40,10 @@ class LaunchConfigurationCacheProvider(
     log.info("Loading cache for ${javaClass.simpleName}")
     val refdAmisByRegion = mutableMapOf<String, MutableMap<String, MutableSet<AmazonLaunchConfiguration>>>()
     val configuredRegions = workConfigurations.map { it.location }.toSet()
+    val configuredAccountIds = workConfigurations.map { it.account.accountId }.toSet()
     accountProvider.getAccounts()
       .filter(isCorrectCloudProviderAndRegion(configuredRegions))
+      .filter { account -> configuredAccountIds.contains(account.accountId) }
       .forEach { account ->
         account.regions?.forEach { region ->
           log.info("Reading launch configurations in {}/{}/{}", account.accountId, region.name, account.environment)


### PR DESCRIPTION
When doing the caching, do not cache accounts that are not part of the work configuration - it could be the case, that such accounts are not allowing the swabbie IAM role to access them - which kill swabbie with "not permitted" exceptions