### PR TITLE
fix(aws): Fixing tagging ami during optout

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -329,7 +329,7 @@ class AmazonImageHandler(
           OrcaJob(
             type = "upsertImageTags",
             context = mutableMapOf(
-              "imageNames" to setOf(markedResource.resourceId),
+              "imageNames" to setOf(markedResource.name),
               "regions" to setOf(workConfiguration.location),
               "tags" to mapOf("expiration_time" to "never"),
               "cloudProvider" to workConfiguration.cloudProvider,


### PR DESCRIPTION
- updated to use image names because orca expects that and not imageId