### PR TITLE
feat(aws): Checking for launch template references in imageHandler

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
@@ -31,8 +31,11 @@ import com.netflix.spinnaker.swabbie.aws.caches.AmazonImagesUsedByInstancesCache
 import com.netflix.spinnaker.swabbie.aws.caches.AmazonImagesUsedByInstancesInMemoryCache
 import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchConfigurationCache
 import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchConfigurationInMemoryCache
+import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchTemplateVersionCache
+import com.netflix.spinnaker.swabbie.aws.caches.AmazonLaunchTemplateVersionInMemoryCache
 import com.netflix.spinnaker.swabbie.aws.caches.ImagesUsedByInstancesProvider
 import com.netflix.spinnaker.swabbie.aws.caches.LaunchConfigurationCacheProvider
+import com.netflix.spinnaker.swabbie.aws.caches.LaunchTemplateVersionsCacheProvider
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import java.time.Clock
 import org.springframework.context.annotation.Bean
@@ -69,6 +72,23 @@ open class AwsConfiguration {
     aws: AWS
   ): CachedViewProvider<AmazonLaunchConfigurationCache> {
     return LaunchConfigurationCacheProvider(clock, workConfigurations, accountProvider, aws)
+  }
+
+  @Bean
+  open fun launchTemplateVersionCacheProvider(
+    clock: Clock,
+    workConfigurations: List<WorkConfiguration>,
+    accountProvider: AccountProvider,
+    aws: AWS
+  ): CachedViewProvider<AmazonLaunchTemplateVersionCache> {
+    return LaunchTemplateVersionsCacheProvider(clock, workConfigurations, accountProvider, aws)
+  }
+
+  @Bean
+  open fun launchTemplateVersionInMemoryCache(
+    provider: CachedViewProvider<AmazonLaunchTemplateVersionCache>
+  ): AmazonLaunchTemplateVersionInMemoryCache {
+    return AmazonLaunchTemplateVersionInMemoryCache(provider)
   }
 
   @Bean

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/AmazonLaunchTemplateVersionCache.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/AmazonLaunchTemplateVersionCache.kt
@@ -1,0 +1,59 @@
+/*
+ *
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License")
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.swabbie.aws.caches
+
+import com.netflix.spinnaker.security.AuthenticatedRequest
+import com.netflix.spinnaker.swabbie.Cacheable
+import com.netflix.spinnaker.swabbie.CachedViewProvider
+import com.netflix.spinnaker.swabbie.InMemorySingletonCache
+import com.netflix.spinnaker.swabbie.aws.Parameters
+import com.netflix.spinnaker.swabbie.aws.launchtemplates.AmazonLaunchTemplateVersion
+
+open class AmazonLaunchTemplateVersionInMemoryCache(
+  private val provider: CachedViewProvider<AmazonLaunchTemplateVersionCache>
+) : InMemorySingletonCache<AmazonLaunchTemplateVersionCache>(
+  { AuthenticatedRequest.allowAnonymous(provider::load) }
+)
+
+data class AmazonLaunchTemplateVersionCache(
+  private val refdAmisByRegion: Map<String, Map<String, Set<AmazonLaunchTemplateVersion>>>,
+  private val lastUpdated: Long,
+  override val name: String?
+) : Cacheable {
+  fun getLaunchTemplateVersionsByRegionForImage(params: Parameters): Set<AmazonLaunchTemplateVersion> {
+    if (params.region != "" && params.id != "") {
+      return getRefdAmisForRegion(params.region).getOrDefault(params.id, emptySet())
+    } else {
+      throw IllegalArgumentException("Missing required region and id parameters")
+    }
+  }
+
+  /**
+   * @param region: AWS region
+   *
+   * Returns a map of <K: all ami's referenced by a launch template in region, V: set of launch templates referencing K>
+   */
+  fun getRefdAmisForRegion(region: String): Map<String, Set<AmazonLaunchTemplateVersion>> {
+    return refdAmisByRegion[region].orEmpty()
+  }
+
+  fun getLastUpdated(): Long {
+    return lastUpdated
+  }
+}

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/LaunchTemplateVersionsCacheProvider.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/caches/LaunchTemplateVersionsCacheProvider.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.swabbie.aws.caches
+
+import com.netflix.spinnaker.swabbie.AccountProvider
+import com.netflix.spinnaker.swabbie.CachedViewProvider
+import com.netflix.spinnaker.swabbie.aws.AWS
+import com.netflix.spinnaker.swabbie.aws.Parameters
+import com.netflix.spinnaker.swabbie.aws.launchtemplates.AmazonLaunchTemplateVersion
+import com.netflix.spinnaker.swabbie.model.Account
+import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import java.time.Clock
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class LaunchTemplateVersionsCacheProvider(
+  private val clock: Clock,
+  private val workConfigurations: List<WorkConfiguration>,
+  private val accountProvider: AccountProvider,
+  private val aws: AWS
+) : CachedViewProvider<AmazonLaunchTemplateVersionCache>, AWS by aws {
+
+  private val log: Logger = LoggerFactory.getLogger(javaClass)
+
+  override fun load(): AmazonLaunchTemplateVersionCache {
+    log.info("Loading cache for ${javaClass.simpleName}")
+    val refdAmisByRegion = mutableMapOf<String, MutableMap<String, MutableSet<AmazonLaunchTemplateVersion>>>()
+    val configuredRegions = workConfigurations.map { it.location }.toSet()
+    accountProvider.getAccounts()
+      .filter(isCorrectCloudProviderAndRegion(configuredRegions))
+      .forEach { account ->
+        account.regions?.forEach { region ->
+          log.info("Reading launch template versions in {}/{}/{}", account.accountId, region.name, account.environment)
+          val launchTemplateVersions: Set<AmazonLaunchTemplateVersion> = getLaunchTemplateVersions(
+            Parameters(
+              region = region.name,
+              account = account.accountId!!,
+              environment = account.environment
+            )
+          ).toSet()
+
+          val refdAmis = mutableMapOf<String, MutableSet<AmazonLaunchTemplateVersion>>()
+          launchTemplateVersions.forEach {
+            if (it.launchTemplateData.imageId != null) {
+              refdAmis.getOrPut(it.launchTemplateData.imageId) { mutableSetOf() }.add(it)
+            }
+          }
+
+          val currentAmis = refdAmisByRegion.getOrDefault(region.name, mutableMapOf())
+          currentAmis.putAll(refdAmis)
+          refdAmisByRegion[region.name] = currentAmis
+        }
+      }
+
+    return AmazonLaunchTemplateVersionCache(refdAmisByRegion, clock.millis(), "default")
+  }
+
+  private fun isCorrectCloudProviderAndRegion(configuredRegions: Set<String>) =
+    { account: Account ->
+      account.cloudProvider == "aws" && !account.regions.isNullOrEmpty() && account.regions!!.any { it.name in configuredRegions }
+    }
+}

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/Edda.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/Edda.kt
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.swabbie.aws.images.AmazonImage
 import com.netflix.spinnaker.swabbie.aws.instances.AmazonInstance
 import com.netflix.spinnaker.swabbie.aws.launchconfigurations.AmazonLaunchConfiguration
 import com.netflix.spinnaker.swabbie.aws.launchtemplates.AmazonLaunchTemplate
+import com.netflix.spinnaker.swabbie.aws.launchtemplates.AmazonLaunchTemplateVersion
 import com.netflix.spinnaker.swabbie.aws.loadbalancers.AmazonElasticLoadBalancer
 import com.netflix.spinnaker.swabbie.aws.securitygroups.AmazonSecurityGroup
 import com.netflix.spinnaker.swabbie.aws.snapshots.AmazonSnapshot
@@ -174,6 +175,23 @@ class Edda(
       eddaService.getAutoScalingGroup(params.id)
     }
   }
+
+  // TODO: This should be updated as it would fail once edda fixes this endpoint
+  // see pattern in other functions
+  // See note in EddaService.getLaunchTemplateVersions
+  override fun getLaunchTemplateVersions(params: Parameters): List<AmazonLaunchTemplateVersion> {
+    val result = call(params, SERVER_GROUP) {
+      eddaService: EddaService ->
+      eddaService.getLaunchTemplateVersions()
+    } ?: emptyList()
+
+    return result.flatMap { it.versions }
+  }
+
+  data class EddaLaunchTemplaVersion(
+    val versions: List<AmazonLaunchTemplateVersion>,
+    val id: String
+  )
 
   private fun <R> call(params: Parameters, resourceType: String, fx: (EddaService) -> R): R? {
     val client = clients[Key(params.account, params.region, params.environment)]

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/EddaService.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/EddaService.kt
@@ -81,4 +81,7 @@ interface EddaService {
 
   @GET("/api/v2/aws/launchTemplates/{launchTemplateId}")
   fun getLaunchTemplate(@Path("launchTemplateId") launchTemplateId: String): AmazonLaunchTemplate
+
+  @GET("/api/v2/view/launchTemplateVersions;_expand")
+  fun getLaunchTemplateVersions(): List<Edda.EddaLaunchTemplaVersion> // TODO: switch to just launchTemplateVersion when edda is updated
 }

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/Rules.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/Rules.kt
@@ -43,7 +43,8 @@ class OrphanedImageRule : Rule {
       USED_BY_INSTANCES,
       USED_BY_LAUNCH_CONFIGURATIONS,
       HAS_SIBLINGS_IN_OTHER_ACCOUNTS,
-      SEEN_IN_USE_RECENTLY
+      SEEN_IN_USE_RECENTLY,
+      USED_BY_LAUNCH_TEMPLATES
     )
     ) {
       return Result(null)
@@ -51,7 +52,7 @@ class OrphanedImageRule : Rule {
 
     return Result(
       Summary(
-        description = "Image is not referenced by an Instance, Launch Configuration, " +
+        description = "Image is not referenced by an Instance, Launch Configuration/Template, " +
           "and has no siblings in other accounts, " +
           "and has been that way for over the outOfUseThreshold days",
         ruleName = name()
@@ -66,5 +67,6 @@ class OrphanedImageRule : Rule {
 
 const val USED_BY_INSTANCES = "usedByInstances"
 const val USED_BY_LAUNCH_CONFIGURATIONS = "usedByLaunchConfigurations"
+const val USED_BY_LAUNCH_TEMPLATES = "usedByLaunchTemplates"
 const val HAS_SIBLINGS_IN_OTHER_ACCOUNTS = "hasSiblingsInOtherAccounts"
 const val SEEN_IN_USE_RECENTLY = "seenInUseRecently"

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchtemplates/AmazonLaunchTemplateVersion.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchtemplates/AmazonLaunchTemplateVersion.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.swabbie.aws.launchtemplates
+
+import com.amazonaws.services.ec2.model.ResponseLaunchTemplateData
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.netflix.spinnaker.swabbie.aws.model.AmazonResource
+import com.netflix.spinnaker.swabbie.model.AWS
+import com.netflix.spinnaker.swabbie.model.LAUNCH_TEMPLATE_VERSION
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@JsonTypeName("amazonLaunchTemplateVersion")
+data class AmazonLaunchTemplateVersion(
+  private val versionNumber: Long = 0,
+  private val launchTemplateId: String? = "",
+  private val launchTemplateName: String? = "",
+  val launchTemplateData: ResponseLaunchTemplateData,
+  private val createdTime: Long,
+  override val resourceId: String = launchTemplateId!! + ":" + versionNumber,
+  override val resourceType: String = LAUNCH_TEMPLATE_VERSION,
+  override val cloudProvider: String = AWS,
+  override val name: String = launchTemplateName!! + ":" + versionNumber,
+  private val creationDate: String? = LocalDateTime.ofInstant(Instant.ofEpochMilli(createdTime), ZoneId.systemDefault()).toString()
+) : AmazonResource(creationDate) {
+  fun getAutoscalingGroupName() =
+    name.substringBeforeLast("-")
+  override fun equals(other: Any?): Boolean {
+    return super.equals(other)
+  }
+
+  override fun hashCode(): Int {
+    return super.hashCode()
+  }
+}

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
@@ -41,6 +41,7 @@ const val LOAD_BALANCER = "loadBalancer"
 const val SERVER_GROUP = "serverGroup"
 const val LAUNCH_CONFIGURATION = "launchConfiguration"
 const val LAUNCH_TEMPLATE = "launchTemplate"
+const val LAUNCH_TEMPLATE_VERSION = "launchTemplateVersion"
 const val SNAPSHOT = "snapshot"
 
 /** Provider Types **/


### PR DESCRIPTION
- added an in-memory cache for use in the imageHandler
- updated imageHandler to check for images used by launch templates