### PR TITLE
fix(core): Evenly distribute delete resources across the configured delete spread time divided by the total number of resource partitions

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandler.kt
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
 import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.MarkedResource
+import com.netflix.spinnaker.swabbie.model.ResourcePartition
 import com.netflix.spinnaker.swabbie.model.ResourceState
 import com.netflix.spinnaker.swabbie.model.SERVER_GROUP
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
@@ -84,10 +85,10 @@ class AmazonAutoScalingGroupHandler(
 ) {
 
   override fun deleteResources(
-    markedResources: List<MarkedResource>,
+    resourcePartition: ResourcePartition,
     workConfiguration: WorkConfiguration
   ) {
-    markedResources.forEach { markedResource ->
+    resourcePartition.markedResources.forEach { markedResource ->
       orcaService.orchestrate(
         OrchestrationRequest(
           application = FriggaReflectiveNamer().deriveMoniker(markedResource).app ?: "swabbie",
@@ -109,7 +110,7 @@ class AmazonAutoScalingGroupHandler(
           taskResponse.taskId(),
           TaskCompleteEventInfo(
             action = Action.DELETE,
-            markedResources = markedResources,
+            markedResources = resourcePartition.markedResources,
             workConfiguration = workConfiguration,
             submittedTimeMillis = clock.instant().toEpochMilli()
           )

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchconfigurations/AmazonLaunchConfigurationHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchconfigurations/AmazonLaunchConfigurationHandler.kt
@@ -27,7 +27,7 @@ import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
 import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.LAUNCH_CONFIGURATION
-import com.netflix.spinnaker.swabbie.model.MarkedResource
+import com.netflix.spinnaker.swabbie.model.ResourcePartition
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.notifications.NotificationQueue
 import com.netflix.spinnaker.swabbie.notifications.Notifier
@@ -80,9 +80,9 @@ class AmazonLaunchConfigurationHandler(
   dynamicConfigService,
   notificationQueue
 ) {
-  override fun deleteResources(markedResources: List<MarkedResource>, workConfiguration: WorkConfiguration) {
-    val application = applicationUtils.determineApp(markedResources.first().resource)
-    val launchConfigurationNames = markedResources
+  override fun deleteResources(resourcePartition: ResourcePartition, workConfiguration: WorkConfiguration) {
+    val application = applicationUtils.determineApp(resourcePartition.markedResources.first().resource)
+    val launchConfigurationNames = resourcePartition.markedResources
       .map {
         it.resourceId
       }.toSet()
@@ -106,7 +106,7 @@ class AmazonLaunchConfigurationHandler(
     ).let { taskResponse ->
       val completeEvent = TaskCompleteEventInfo(
         action = Action.DELETE,
-        markedResources = markedResources,
+        markedResources = resourcePartition.markedResources,
         workConfiguration = workConfiguration,
         submittedTimeMillis = clock.instant().toEpochMilli()
       )

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchtemplates/AmazonLaunchTemplateHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/launchtemplates/AmazonLaunchTemplateHandler.kt
@@ -27,7 +27,7 @@ import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
 import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.LAUNCH_TEMPLATE
-import com.netflix.spinnaker.swabbie.model.MarkedResource
+import com.netflix.spinnaker.swabbie.model.ResourcePartition
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.notifications.NotificationQueue
 import com.netflix.spinnaker.swabbie.notifications.Notifier
@@ -80,9 +80,9 @@ class AmazonLaunchTemplateHandler(
   dynamicConfigService,
   notificationQueue
 ) {
-  override fun deleteResources(markedResources: List<MarkedResource>, workConfiguration: WorkConfiguration) {
-    val application = applicationUtils.determineApp(markedResources.first().resource)
-    val launTemplateIds = markedResources
+  override fun deleteResources(resourcePartition: ResourcePartition, workConfiguration: WorkConfiguration) {
+    val application = applicationUtils.determineApp(resourcePartition.markedResources.first().resource)
+    val launTemplateIds = resourcePartition.markedResources
       .map {
         it.resourceId
       }.toSet()
@@ -106,7 +106,7 @@ class AmazonLaunchTemplateHandler(
     ).let { taskResponse ->
       val completeEvent = TaskCompleteEventInfo(
         action = Action.DELETE,
-        markedResources = markedResources,
+        markedResources = resourcePartition.markedResources,
         workConfiguration = workConfiguration,
         submittedTimeMillis = clock.instant().toEpochMilli()
       )

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/loadbalancers/AmazonLoadBalancerHandler.kt
@@ -27,7 +27,7 @@ import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
 import com.netflix.spinnaker.swabbie.model.AWS
 import com.netflix.spinnaker.swabbie.model.LOAD_BALANCER
-import com.netflix.spinnaker.swabbie.model.MarkedResource
+import com.netflix.spinnaker.swabbie.model.ResourcePartition
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.notifications.NotificationQueue
 import com.netflix.spinnaker.swabbie.notifications.Notifier
@@ -80,10 +80,10 @@ class AmazonLoadBalancerHandler(
   notificationQueue
 ) {
   override fun deleteResources(
-    markedResources: List<MarkedResource>,
+    resourcePartition: ResourcePartition,
     workConfiguration: WorkConfiguration
   ) {
-    markedResources.forEach { markedResource ->
+    resourcePartition.markedResources.forEach { markedResource ->
       markedResource.resource.let { resource ->
         if (resource is AmazonElasticLoadBalancer && !workConfiguration.dryRun) {
           // TODO: consider also removing dns records for the ELB
@@ -108,7 +108,7 @@ class AmazonLoadBalancerHandler(
               taskResponse.taskId(),
               TaskCompleteEventInfo(
                 action = Action.DELETE,
-                markedResources = markedResources,
+                markedResources = resourcePartition.markedResources,
                 workConfiguration = workConfiguration,
                 submittedTimeMillis = clock.instant().toEpochMilli()
               )

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/securitygroups/AmazonSecurityGroupHandler.kt
@@ -26,7 +26,7 @@ import com.netflix.spinnaker.swabbie.aws.Parameters
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
 import com.netflix.spinnaker.swabbie.model.AWS
-import com.netflix.spinnaker.swabbie.model.MarkedResource
+import com.netflix.spinnaker.swabbie.model.ResourcePartition
 import com.netflix.spinnaker.swabbie.model.SECURITY_GROUP
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
 import com.netflix.spinnaker.swabbie.notifications.NotificationQueue
@@ -80,10 +80,10 @@ class AmazonSecurityGroupHandler(
   notificationQueue
 ) {
   override fun deleteResources(
-    markedResources: List<MarkedResource>,
+    resourcePartition: ResourcePartition,
     workConfiguration: WorkConfiguration
   ) {
-    markedResources.forEach { markedResource ->
+    resourcePartition.markedResources.forEach { markedResource ->
       markedResource.resource.let { resource ->
         if (resource is AmazonSecurityGroup && !workConfiguration.dryRun) {
           log.debug("This resource is about to be deleted {}", markedResource)
@@ -109,7 +109,7 @@ class AmazonSecurityGroupHandler(
               taskResponse.taskId(),
               TaskCompleteEventInfo(
                 action = Action.DELETE,
-                markedResources = markedResources,
+                markedResources = resourcePartition.markedResources,
                 workConfiguration = workConfiguration,
                 submittedTimeMillis = clock.instant().toEpochMilli()
               )

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandlerTest.kt
@@ -128,6 +128,8 @@ object AmazonAutoScalingGroupHandlerTest {
     whenever(aws.getServerGroups(params)) doReturn listOf(sg1, sg2)
     whenever(dynamicConfigService.getConfig(any(), any(), eq(workConfiguration.maxItemsProcessedPerCycle))) doReturn
       workConfiguration.maxItemsProcessedPerCycle
+    whenever(dynamicConfigService.getConfig(any(), any(), eq(workConfiguration.deleteSpreadMs))) doReturn
+      workConfiguration.deleteSpreadMs
   }
 
   @AfterEach

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
@@ -172,6 +172,9 @@ object AmazonImageHandlerTest {
 
     whenever(dynamicConfigService.getConfig(any(), any(), eq(workConfiguration.maxItemsProcessedPerCycle))) doReturn
       workConfiguration.maxItemsProcessedPerCycle
+
+    whenever(dynamicConfigService.getConfig(any(), any(), eq(workConfiguration.deleteSpreadMs))) doReturn
+      workConfiguration.deleteSpreadMs
   }
 
   @AfterEach

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/launchconfigurations/AmazonLaunchConfigurationHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/launchconfigurations/AmazonLaunchConfigurationHandlerTest.kt
@@ -129,6 +129,9 @@ object AmazonLaunchConfigurationHandlerTest {
     whenever(aws.getLaunchConfigurations(params)) doReturn listOf(lc1, lc2)
     whenever(dynamicConfigService.getConfig(any(), any(), eq(workConfiguration.maxItemsProcessedPerCycle))) doReturn
       workConfiguration.maxItemsProcessedPerCycle
+
+    whenever(dynamicConfigService.getConfig(any(), any(), eq(workConfiguration.deleteSpreadMs))) doReturn
+      workConfiguration.deleteSpreadMs
   }
 
   @AfterEach

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/launchtemplates/AmazonLaunchTemplateHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/launchtemplates/AmazonLaunchTemplateHandlerTest.kt
@@ -130,6 +130,9 @@ object AmazonLaunchTemplateHandlerTest {
     whenever(aws.getLaunchTemplates(params)) doReturn listOf(lt1, lt2)
     whenever(dynamicConfigService.getConfig(any(), any(), eq(workConfiguration.maxItemsProcessedPerCycle))) doReturn
       workConfiguration.maxItemsProcessedPerCycle
+
+    whenever(dynamicConfigService.getConfig(any(), any(), eq(workConfiguration.deleteSpreadMs))) doReturn
+      workConfiguration.deleteSpreadMs
   }
 
   @AfterEach

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Resource.kt
@@ -389,3 +389,8 @@ data class ResourceEvaluation(
   val wouldMarkReason: String,
   val summaries: List<Summary>
 )
+
+data class ResourcePartition(
+  var offsetMs: Long = 0,
+  val markedResources: List<MarkedResource>
+)

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/WorkConfiguration.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/WorkConfiguration.kt
@@ -41,6 +41,7 @@ data class WorkConfiguration(
   val maxAge: Int = 14,
   val maxItemsProcessedPerCycle: Int = 10,
   val itemsProcessedBatchSize: Int = 5,
+  val deleteSpreadMs: Long = 0L,
   val enabledActions: List<Action> = listOf(Action.MARK, Action.NOTIFY, Action.DELETE),
   val enabledRules: Set<ResourceTypeConfiguration.RuleConfiguration> = setOf()
 ) {
@@ -65,6 +66,11 @@ data class WorkConfiguration(
   fun getMaxItemsProcessedPerCycle(dynamicConfigService: DynamicConfigService): Int {
     val key = "$namespace.max-items-processed-per-cycle"
     return dynamicConfigService.getConfig(Int::class.java, key, maxItemsProcessedPerCycle)
+  }
+
+  fun getDeleteSpreadMs(dynamicConfigService: DynamicConfigService): Long {
+    val key = "$namespace.delete-spread-ms"
+    return dynamicConfigService.getConfig(Long::class.java, key, deleteSpreadMs)
   }
 }
 

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/TestResourceTypeHandler.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/TestResourceTypeHandler.kt
@@ -25,9 +25,9 @@ import com.netflix.spinnaker.config.SwabbieProperties
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.swabbie.events.Action
 import com.netflix.spinnaker.swabbie.exclusions.ResourceExclusionPolicy
-import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.Resource
 import com.netflix.spinnaker.swabbie.model.ResourceEvaluation
+import com.netflix.spinnaker.swabbie.model.ResourcePartition
 import com.netflix.spinnaker.swabbie.model.Result
 import com.netflix.spinnaker.swabbie.model.Rule
 import com.netflix.spinnaker.swabbie.model.Summary
@@ -86,10 +86,10 @@ class TestResourceTypeHandler(
   }
 
   override fun deleteResources(
-    markedResources: List<MarkedResource>,
+    resourcePartition: ResourcePartition,
     workConfiguration: WorkConfiguration
   ) {
-    markedResources.forEach { m ->
+    resourcePartition.markedResources.forEach { m ->
       val found = simulatedCandidates.contains(m.resource)
       if (found) {
         simulatedCandidates.remove(m.resource)

--- a/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaService.kt
+++ b/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaService.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.swabbie.orca
 
+import java.util.concurrent.TimeUnit
 import retrofit.http.Body
 import retrofit.http.GET
 import retrofit.http.Headers
@@ -101,6 +102,25 @@ fun generateWaitStageWithRandWaitTime(ceiling: Long, stageId: String = "0", requ
     type = "wait",
     context = mutableMapOf(
       "waitTime" to generateRandomWaitTimeS(ceiling),
+      "refId" to stageId,
+      "requisiteStageRefIds" to requisiteStageRefIds
+    )
+  )
+
+/**
+ * Generates a wait stage with a fixed wait time.
+ *
+ * This stage is meant to be used at the start of an orca task to stagger
+ * the start of many delete tasks, and the default [stageId] is 0.
+ *
+ * Optionally, you can add a [stageId] and [requisiteStageRefIds] to
+ * construct a stage you can place anywhere in your pipeline.
+ */
+fun generatedWaitStageWithFixedWaitTime(waitTimeMs: Long, stageId: String = "0", requisiteStageRefIds: List<String> = emptyList()) =
+  OrcaJob(
+    type = "wait",
+    context = mutableMapOf(
+      "waitTime" to TimeUnit.MILLISECONDS.toSeconds(waitTimeMs),
       "refId" to stageId,
       "requisiteStageRefIds" to requisiteStageRefIds
     )


### PR DESCRIPTION
Previously, we had jitter across a fixed range that was added to these deletes.  This still ended up with deletes being clumped into a fairly tight window, which caused AWS rate limiting in downstream services.  This proposes to delete across an evenly distributed time window.