### PR TITLE
fix(core): Limit number of in-progress tasks submitted when deleting resources

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/config/SwabbieProperties.kt
@@ -133,6 +133,7 @@ class ResourceTypeConfiguration {
   var entityTaggingEnabled: Boolean = false
   var maxAge: Int = 14
   var notification: NotificationConfiguration = EmptyNotificationConfiguration()
+  var maxTasksPerBatch: Int = 200
   var enabledRules: Set<RuleConfiguration> = setOf()
 
   /**

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/WorkConfigurator.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/WorkConfigurator.kt
@@ -98,6 +98,7 @@ open class WorkConfigurator(
               entityTaggingEnabled = resourceTypeConfiguration.entityTaggingEnabled,
               maxAge = resourceTypeConfiguration.maxAge,
               maxItemsProcessedPerCycle = cloudProviderConfiguration.maxItemsProcessedPerCycle,
+              maxTasksPerBatch = resourceTypeConfiguration.maxTasksPerBatch,
               itemsProcessedBatchSize = cloudProviderConfiguration.itemsProcessedBatchSize,
               enabledActions = resourceTypeConfiguration.enabledActions,
               enabledRules = resourceTypeConfiguration.enabledRules

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/events/Event.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/events/Event.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.swabbie.events
 
 import com.netflix.spinnaker.swabbie.model.MarkedResource
 import com.netflix.spinnaker.swabbie.model.WorkConfiguration
+import org.springframework.context.ApplicationEvent
 
 abstract class Event(
   open val action: Action,
@@ -74,3 +75,5 @@ class OrcaTaskFailureEvent(
   override val markedResource: MarkedResource,
   override val workConfiguration: WorkConfiguration
 ) : Event(action, markedResource, workConfiguration)
+
+class OrcaTasksStatusRefreshed(source: Any) : ApplicationEvent(source)

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Tasks.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/Tasks.kt
@@ -1,0 +1,5 @@
+package com.netflix.spinnaker.swabbie.model
+
+interface ResourceResponse
+
+data class Tasks(var taskIds: List<String> = mutableListOf()) : ResourceResponse

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/WorkConfiguration.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/model/WorkConfiguration.kt
@@ -41,6 +41,7 @@ data class WorkConfiguration(
   val maxAge: Int = 14,
   val maxItemsProcessedPerCycle: Int = 10,
   val itemsProcessedBatchSize: Int = 5,
+  val maxTasksPerBatch: Int = 200,
   val enabledActions: List<Action> = listOf(Action.MARK, Action.NOTIFY, Action.DELETE),
   val enabledRules: Set<ResourceTypeConfiguration.RuleConfiguration> = setOf()
 ) {

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/InMemoryTaskTrackingRepository.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/InMemoryTaskTrackingRepository.kt
@@ -72,7 +72,7 @@ class InMemoryTaskTrackingRepository(
     return submittedTasks[taskId]
   }
 
-  override fun cleanUpFinishedTasks(daysToLeave: Int) {
+  override fun cleanUpTasks(daysToLeave: Int) {
     getAllBefore(daysToLeave).forEach { taskId ->
       submittedTasks.remove(taskId)
       taskStatus.remove(taskId)

--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/TaskTrackingRepository.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/repository/TaskTrackingRepository.kt
@@ -31,7 +31,7 @@ interface TaskTrackingRepository {
   fun getFailed(): Set<String>
   fun getSucceeded(): Set<String>
   fun getTaskDetail(taskId: String): TaskCompleteEventInfo?
-  fun cleanUpFinishedTasks(daysToLeave: Int = 2)
+  fun cleanUpTasks(daysToLeave: Int = 2)
 }
 
 data class TaskCompleteEventInfo(

--- a/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaTaskMonitoringAgent.kt
+++ b/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/swabbie/orca/OrcaTaskMonitoringAgent.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.kork.discovery.DiscoveryStatusListener
 import com.netflix.spinnaker.kork.lock.LockManager
 import com.netflix.spinnaker.swabbie.LockingService
 import com.netflix.spinnaker.swabbie.events.OrcaTaskFailureEvent
+import com.netflix.spinnaker.swabbie.events.OrcaTasksStatusRefreshed
 import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import java.time.Clock
 import java.time.Duration
@@ -164,6 +165,7 @@ class OrcaTaskMonitoringAgent(
       }
 
     clean()
+    applicationEventPublisher.publishEvent(OrcaTasksStatusRefreshed(this))
   }
 
   private fun getTask(taskId: String): TaskDetailResponse =
@@ -175,7 +177,7 @@ class OrcaTaskMonitoringAgent(
     )
 
   private fun clean() {
-    taskTrackingRepository.cleanUpFinishedTasks(daysToKeepTasks)
+    taskTrackingRepository.cleanUpTasks(daysToKeepTasks)
   }
 
   @Value("\${swabbie.agents.orca-task-monitor.interval-seconds:60}")

--- a/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisTaskTrackingRepository.kt
+++ b/swabbie-redis/src/main/kotlin/com/netflix/spinnaker/swabbie/redis/RedisTaskTrackingRepository.kt
@@ -160,8 +160,7 @@ class RedisTaskTrackingRepository(
       .keys
   }
 
-  // todo eb: this actually cleans up running tasks as well
-  override fun cleanUpFinishedTasks(daysToLeave: Int) {
+  override fun cleanUpTasks(daysToLeave: Int) {
     val allBefore: Set<String> = getAllBefore(daysToLeave)
     if (allBefore.isEmpty()) return
 

--- a/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisTaskTrackingRepositoryTest.kt
+++ b/swabbie-redis/src/test/kotlin/com/netflix/spinnaker/swabbie/redis/RedisTaskTrackingRepositoryTest.kt
@@ -149,7 +149,7 @@ object RedisTaskTrackingRepositoryTest {
   fun `should delete old task when asked`() {
     trackingRepository.add(taskId, oldTaskInfo)
 
-    trackingRepository.cleanUpFinishedTasks(2)
+    trackingRepository.cleanUpTasks(2)
 
     Assert.isTrue(trackingRepository.getInProgress() == emptySet<String>(), "should have no more resources")
   }


### PR DESCRIPTION
Different proposal than https://github.com/spinnaker/swabbie/pull/542

This one is basically to limit the number of in-progress Orca task on a per resource type basis.

⚠️ No tests yet, build fails. ⚠️ 