### PR TITLE
fix(launchTemplates): Pull aws launch template version from edda

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/Edda.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/Edda.kt
@@ -176,22 +176,12 @@ class Edda(
     }
   }
 
-  // TODO: This should be updated as it would fail once edda fixes this endpoint
-  // see pattern in other functions
-  // See note in EddaService.getLaunchTemplateVersions
   override fun getLaunchTemplateVersions(params: Parameters): List<AmazonLaunchTemplateVersion> {
-    val result = call(params, SERVER_GROUP) {
+    return call(params, SERVER_GROUP) {
       eddaService: EddaService ->
       eddaService.getLaunchTemplateVersions()
     } ?: emptyList()
-
-    return result.flatMap { it.versions }
   }
-
-  data class EddaLaunchTemplaVersion(
-    val versions: List<AmazonLaunchTemplateVersion>,
-    val id: String
-  )
 
   private fun <R> call(params: Parameters, resourceType: String, fx: (EddaService) -> R): R? {
     val client = clients[Key(params.account, params.region, params.environment)]

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/EddaService.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/edda/EddaService.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.swabbie.aws.images.AmazonImage
 import com.netflix.spinnaker.swabbie.aws.instances.AmazonInstance
 import com.netflix.spinnaker.swabbie.aws.launchconfigurations.AmazonLaunchConfiguration
 import com.netflix.spinnaker.swabbie.aws.launchtemplates.AmazonLaunchTemplate
+import com.netflix.spinnaker.swabbie.aws.launchtemplates.AmazonLaunchTemplateVersion
 import com.netflix.spinnaker.swabbie.aws.loadbalancers.AmazonElasticLoadBalancer
 import com.netflix.spinnaker.swabbie.aws.securitygroups.AmazonSecurityGroup
 import com.netflix.spinnaker.swabbie.aws.snapshots.AmazonSnapshot
@@ -82,6 +83,6 @@ interface EddaService {
   @GET("/api/v2/aws/launchTemplates/{launchTemplateId}")
   fun getLaunchTemplate(@Path("launchTemplateId") launchTemplateId: String): AmazonLaunchTemplate
 
-  @GET("/api/v2/view/launchTemplateVersions;_expand")
-  fun getLaunchTemplateVersions(): List<Edda.EddaLaunchTemplaVersion> // TODO: switch to just launchTemplateVersion when edda is updated
+  @GET("/api/v2/aws/launchTemplateVersions;_expand")
+  fun getLaunchTemplateVersions(): List<AmazonLaunchTemplateVersion>
 }

--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandler.kt
@@ -215,9 +215,10 @@ class AmazonImageHandler(
     ) {
       throw StaleCacheException("Amazon launch configuration cache over 1 hour old, aborting.")
     }
+    val imagesUsedByLaunchTemplatesForRegion = launchTemplateVersionCache.get().getRefdAmisForRegion(params.region).keys
     val imagesUsedByLaunchConfigsForRegion = launchConfigurationCache.get().getRefdAmisForRegion(params.region).keys
     log.info("Checking the {} images used by launch configurations.", imagesUsedByLaunchConfigsForRegion.size)
-    if (imagesUsedByLaunchConfigsForRegion.size < swabbieProperties.minImagesUsedByLC) {
+    if ((imagesUsedByLaunchTemplatesForRegion.size + imagesUsedByLaunchConfigsForRegion.size) < swabbieProperties.minImagesUsedByLC) {
       throw CacheSizeException(
         "Amazon launch configuration cache contains less than " +
           "${swabbieProperties.minImagesUsedByLC} images used, aborting for safety."

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManagerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManagerTest.kt
@@ -71,28 +71,10 @@ object WorkQueueManagerTest {
   }
 
   @Test
-  fun `when down queue should not be filled`() {
-    whenever(discoveryStatusListener.isEnabled) doReturn false
-    workQueueManager.onApplicationEvent(downEvent)
-    workQueueManager.monitor()
-    expectThat(workQueue.isEmpty()).isTrue()
-  }
-
-  @Test
-  fun `when down queue should not be emptied`() {
-    whenever(discoveryStatusListener.isEnabled) doReturn false
-    workQueueManager.onApplicationEvent(downEvent)
-    workQueue.seed()
-    workQueueManager.monitor()
-    expectThat(workQueue.isEmpty()).isFalse()
-  }
-
-  @Test
   fun `when up and enabled queue should be filled`() {
     whenever(dynamicConfigService.isEnabled(SWABBIE_FLAG_PROPERY, false)) doReturn false
     whenever(discoveryStatusListener.isEnabled) doReturn true
 
-    workQueueManager.onApplicationEvent(upEvent)
     workQueueManager.monitor()
 
     expectThat(workQueue.isEmpty()).isFalse()
@@ -103,7 +85,6 @@ object WorkQueueManagerTest {
     whenever(dynamicConfigService.isEnabled(SWABBIE_FLAG_PROPERY, false)) doReturn true
     whenever(discoveryStatusListener.isEnabled) doReturn true
 
-    workQueueManager.onApplicationEvent(upEvent)
     workQueueManager.monitor()
 
     expectThat(workQueue.isEmpty()).isTrue()


### PR DESCRIPTION
- Additionally, since the total number of launch configs will diminish over time we also need to compare the total number of launch templates + launch configs when checking if images are used by launch configurations
- Removes an unnecessary sleep (which would be interrupted, throw an error, add noise to the logs) - now just check if caches are loaded as part of the normal monitor `WorkQueueManager#monitor` cycle