### PR TITLE
feat(ci): Add Dockerfile for compile & build - WIP

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,0 +1,8 @@
+FROM ubuntu:bionic
+RUN apt-get update && apt-get install -y \
+    openjdk-11-jdk \
+ && rm -rf /var/lib/apt/lists/*
+LABEL maintainer="sig-platform@spinnaker.io"
+ENV GRADLE_USER_HOME /workspace/.gradle
+ENV GRADLE_OPTS "-Xmx4g -Xms2g"
+CMD ./gradlew --no-daemon swabbie-web:installDist -x test

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,32 @@
+FROM python:3.7-alpine3.12
+LABEL maintainer="sig-platform@spinnaker.io"
+
+ENV AWS_CLI_VERSION=1.18.152
+
+ENV PATH "$PATH:/usr/local/bin/"
+
+RUN apk update \
+  && apk upgrade \
+  && apk --no-cache add --update \
+    bash \
+    ca-certificates \
+    wget \
+    openjdk11 \
+    git \
+    openssh-client
+
+# AWS CLI
+RUN pip install --upgrade awscli==${AWS_CLI_VERSION} python-magic \
+  && pip uninstall -y pip
+
+RUN rm /var/cache/apk/*
+
+RUN addgroup -S -g 10111 spinnaker
+RUN adduser -S -G spinnaker -u 10111 spinnaker
+
+COPY swabbie-web/build/install/swabbie /opt/swabbie
+RUN mkdir -p /opt/swabbie/plugins && chown -R spinnaker:nogroup /opt/swabbie/plugins
+
+USER spinnaker
+
+CMD ["/opt/swabbie/bin/swabbie"]


### PR DESCRIPTION
- Copied from Clouddriver and removed unused utilites.
- Whilst Swabbie doesn't exec `aws` CLI I think, it tends to be useful to have to validate IAM/operations in the container. Happy to remove.
