### PR TITLE
chore(swabbie): Fix package resolution and update to Kotlin 1.6.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,9 @@
  */
 
 plugins {
-  id("io.spinnaker.project") version "$spinnakerGradleVersion" apply false
-  id("nebula.kotlin") version "1.3.70" apply false
-  id("org.jetbrains.dokka") version "0.9.18" apply false
+  id "io.spinnaker.project" version "$spinnakerGradleVersion" apply false
+  id "org.jetbrains.kotlin.jvm" version "$kotlinVersion" apply false
+  id "org.jetbrains.dokka" version "1.7.20" apply false
 }
 
 allprojects {
@@ -29,7 +29,7 @@ allprojects {
     }
   }
 
-  group = "com.netflix.spinnaker.swabbie"
+  group = "io.spinnaker.swabbie"
 
   configurations.all {
     exclude group: "javax.servlet", module: "servlet-api"
@@ -44,13 +44,9 @@ allprojects {
     apply from: "$rootDir/gradle/license.gradle"
     apply from: "$rootDir/gradle/dokka.gradle"
 
-    repositories {
-      jcenter()
-    }
-
     dependencies {
-      api(platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion"))
-      annotationProcessor(platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion"))
+      api(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
+      annotationProcessor(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
       annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 korkVersion=7.150.0
-kotlinVersion=1.4.0
+kotlinVersion=1.6.21
 org.gradle.parallel=true
 spinnakerGradleVersion=8.23.0
 targetJava11=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
-korkVersion=7.106.0
+korkVersion=7.150.0
+kotlinVersion=1.4.0
 org.gradle.parallel=true
-spinnakerGradleVersion=8.10.1
+spinnakerGradleVersion=8.23.0
 targetJava11=true
-
 # To enable a composite reference to a project, set the
 #  project property `'<projectName>Composite=true'`.
 #

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-korkVersion=7.150.0
+korkVersion=7.158.0
 kotlinVersion=1.6.21
 org.gradle.parallel=true
-spinnakerGradleVersion=8.23.0
+spinnakerGradleVersion=8.25.0
 targetJava11=true
 # To enable a composite reference to a project, set the
 #  project property `'<projectName>Composite=true'`.

--- a/gradle/dokka.gradle
+++ b/gradle/dokka.gradle
@@ -1,8 +1,11 @@
 apply plugin: "org.jetbrains.dokka"
 
-dokka {
-  outputFormat = "html"
-  outputDirectory = "$buildDir/javadoc"
-  jdkVersion = 11
+tasks.named("dokkaHtml").configure {
+  outputDirectory.set(new File("$buildDir/javadoc"))
+
+  dokkaSourceSets {
+    configureEach {
+      jdkVersion.set(11)
+    }
+  }
 }
-tasks.getByName("build").doLast { dokka }

--- a/gradle/junit5.gradle
+++ b/gradle/junit5.gradle
@@ -15,11 +15,11 @@
  */
 
 dependencies {
-  testCompile "org.junit.platform:junit-platform-runner"
-  testCompile "com.nhaarman:mockito-kotlin"
-  testCompile "com.natpryce:hamkrest"
-  testCompile "org.junit.jupiter:junit-jupiter-api"
-  testCompile "org.junit.jupiter:junit-jupiter-params"
+  testImplementation "org.junit.platform:junit-platform-runner"
+  testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
+  testImplementation "com.natpryce:hamkrest"
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.jupiter:junit-jupiter-params"
 
   testRuntime "org.junit.platform:junit-platform-launcher"
   testRuntime "org.junit.jupiter:junit-jupiter-engine"

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -14,18 +14,28 @@
  * limitations under the License.
  */
 
-apply plugin: "nebula.kotlin"
+apply plugin: "kotlin"
 
 compileKotlin {
   kotlinOptions {
-    languageVersion = "1.3"
+    languageVersion = "1.4"
     jvmTarget = "11"
   }
 }
 
 compileTestKotlin {
   kotlinOptions {
-    languageVersion = "1.3"
+    languageVersion = "1.4"
     jvmTarget = "11"
+  }
+}
+
+configurations.all {
+  resolutionStrategy {
+    eachDependency { details ->
+      if (details.requested.group == "org.jetbrains.kotlin") {
+        details.useVersion kotlinVersion
+      }
+    }
   }
 }

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/AmazonAutoScalingGroupHandlerTest.kt
@@ -42,27 +42,27 @@ import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.rules.ResourceRulesEngine
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.validateMockitoUsage
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.whenever
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.validateMockitoUsage
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isTrue
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 
 object AmazonAutoScalingGroupHandlerTest {
   private val aws = mock<AWS>()

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/NotInDiscoveryRuleTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/NotInDiscoveryRuleTest.kt
@@ -19,18 +19,18 @@ package com.netflix.spinnaker.swabbie.aws.autoscalinggroups
 import com.netflix.appinfo.InstanceInfo
 import com.netflix.discovery.DiscoveryClient
 import com.netflix.spinnaker.config.ResourceTypeConfiguration.RuleDefinition
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import strikt.api.expectThat
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.Optional
-import org.junit.jupiter.api.Test
-import strikt.api.expectThat
-import strikt.assertions.isNotNull
-import strikt.assertions.isNull
 
 object NotInDiscoveryRuleTest {
   private val clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/ZeroInstanceInDiscoveryDisabledServerGroupRuleTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/autoscalinggroups/ZeroInstanceInDiscoveryDisabledServerGroupRuleTest.kt
@@ -19,19 +19,19 @@ package com.netflix.spinnaker.swabbie.aws.autoscalinggroups
 import com.amazonaws.services.autoscaling.model.SuspendedProcess
 import com.netflix.appinfo.InstanceInfo
 import com.netflix.discovery.DiscoveryClient
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import strikt.api.expectThat
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.Optional
-import org.junit.jupiter.api.Test
-import strikt.api.expectThat
-import strikt.assertions.isNotNull
-import strikt.assertions.isNull
 
 object ZeroInstanceInDiscoveryDisabledServerGroupRuleTest {
 

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/images/AmazonImageHandlerTest.kt
@@ -46,31 +46,31 @@ import com.netflix.spinnaker.swabbie.repository.UsedResourceRepository
 import com.netflix.spinnaker.swabbie.rules.ResourceRulesEngine
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.doThrow
-import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
-import java.time.Clock
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneOffset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.validateMockitoUsage
 import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isNull
 import strikt.assertions.isTrue
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 object AmazonImageHandlerTest {
   private val resourceRepository = mock<ResourceTrackingRepository>()

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/launchconfigurations/AmazonLaunchConfigurationHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/launchconfigurations/AmazonLaunchConfigurationHandlerTest.kt
@@ -42,28 +42,28 @@ import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.rules.ResourceRulesEngine
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.validateMockitoUsage
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.whenever
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.validateMockitoUsage
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isNull
 import strikt.assertions.isTrue
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 
 object AmazonLaunchConfigurationHandlerTest {
   private val aws = mock<AWS>()

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/launchtemplates/AmazonLaunchTemplateHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/launchtemplates/AmazonLaunchTemplateHandlerTest.kt
@@ -43,28 +43,28 @@ import com.netflix.spinnaker.swabbie.repository.TaskTrackingRepository
 import com.netflix.spinnaker.swabbie.rules.ResourceRulesEngine
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.validateMockitoUsage
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.whenever
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.validateMockitoUsage
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isNull
 import strikt.assertions.isTrue
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 
 object AmazonLaunchTemplateHandlerTest {
   private val aws = mock<AWS>()

--- a/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandlerTest.kt
+++ b/swabbie-aws/src/test/java/com/netflix/spinnaker/swabbie/aws/snapshots/AmazonSnapshotHandlerTest.kt
@@ -44,30 +44,30 @@ import com.netflix.spinnaker.swabbie.repository.UsedResourceRepository
 import com.netflix.spinnaker.swabbie.rules.ResourceRulesEngine
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
 import com.netflix.spinnaker.swabbie.utils.ApplicationUtils
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.doThrow
-import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.validateMockitoUsage
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.whenever
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.validateMockitoUsage
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isNull
 import strikt.assertions.isTrue
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 
 object AmazonSnapshotHandlerTest {
   private val objectMapper = ObjectMapper().registerKotlinModule().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)

--- a/swabbie-aws/swabbie-aws.gradle
+++ b/swabbie-aws/swabbie-aws.gradle
@@ -20,18 +20,18 @@ dependencies {
   implementation project(":swabbie-retrofit")
 
   implementation "com.netflix.eureka:eureka-client"
-  implementation "com.netflix.spinnaker.kork:kork-aws:$korkVersion"
+  implementation "io.spinnaker.kork:kork-aws:$korkVersion"
   implementation "com.netflix.awsobjectmapper:awsobjectmapper"
   implementation "com.amazonaws:aws-java-sdk-ec2"
   implementation "com.amazonaws:aws-java-sdk-autoscaling"
   implementation "com.amazonaws:aws-java-sdk-sts"
   implementation "com.amazonaws:aws-java-sdk-elasticloadbalancing"
   implementation "com.netflix.frigga:frigga"
-  implementation "com.netflix.spinnaker.kork:kork-moniker"
+  implementation "io.spinnaker.kork:kork-moniker"
   implementation "net.logstash.logback:logstash-logback-encoder"
   implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-web"
 
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.okhttp:okhttp-apache"
@@ -39,6 +39,6 @@ dependencies {
   implementation "com.squareup.retrofit:converter-jackson"
 
   testImplementation project(":swabbie-test")
-  testImplementation "com.netflix.spinnaker.kork:kork-test"
+  testImplementation "io.spinnaker.kork:kork-test"
   testImplementation "io.strikt:strikt-core"
 }

--- a/swabbie-bom/swabbie-bom.gradle
+++ b/swabbie-bom/swabbie-bom.gradle
@@ -21,7 +21,7 @@ javaPlatform {
 }
 
 dependencies {
-  api(platform("com.netflix.spinnaker.kork:kork-bom:$korkVersion"))
+  api(platform("io.spinnaker.kork:kork-bom:$korkVersion"))
 
   constraints {
     rootProject

--- a/swabbie-clouddriver/swabbie-clouddriver.gradle
+++ b/swabbie-clouddriver/swabbie-clouddriver.gradle
@@ -17,12 +17,12 @@
 dependencies {
   implementation project(":swabbie-retrofit")
   implementation project(":swabbie-core")
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-web"
   implementation "com.fasterxml.jackson.core:jackson-annotations"
   implementation "com.fasterxml.jackson.core:jackson-core"
   implementation "com.fasterxml.jackson.core:jackson-databind"
-  implementation "com.netflix.spinnaker.kork:kork-moniker"
+  implementation "io.spinnaker.kork:kork-moniker"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.okhttp:okhttp-apache"

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/ResourceTypeHandlerTest.kt
@@ -43,27 +43,22 @@ import com.netflix.spinnaker.swabbie.test.TEST_RESOURCE_PROVIDER_TYPE
 import com.netflix.spinnaker.swabbie.test.TEST_RESOURCE_TYPE
 import com.netflix.spinnaker.swabbie.test.TestResource
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.argWhere
-import com.nhaarman.mockito_kotlin.check
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.eq
-import com.nhaarman.mockito_kotlin.inOrder
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.never
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
-import java.time.temporal.ChronoUnit
-import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.check
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
@@ -71,6 +66,11 @@ import strikt.assertions.isFalse
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 import strikt.assertions.isTrue
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
 
 object ResourceTypeHandlerTest {
   private val resourceRepository = mock<ResourceTrackingRepository>()

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/WorkConfiguratorTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/WorkConfiguratorTest.kt
@@ -28,15 +28,15 @@ import com.netflix.spinnaker.swabbie.exclusions.AccountExclusionPolicy
 import com.netflix.spinnaker.swabbie.model.EmptyAccount
 import com.netflix.spinnaker.swabbie.model.Region
 import com.netflix.spinnaker.swabbie.model.SpinnakerAccount
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
-import java.util.Optional
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import strikt.api.expectThat
 import strikt.assertions.contains
 import strikt.assertions.isEqualTo
+import java.util.Optional
 
 object WorkConfiguratorTest {
   private val accountProvider: AccountProvider = mock()

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManagerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceStateManagerTest.kt
@@ -25,18 +25,18 @@ import com.netflix.spinnaker.swabbie.repository.ResourceStateRepository
 import com.netflix.spinnaker.swabbie.tagging.ResourceTagger
 import com.netflix.spinnaker.swabbie.test.TestResource
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.argWhere
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Test
 
 object ResourceStateManagerTest {
   private val resourceStateRepository = mock<ResourceStateRepository>()

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceTrackingManagerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/events/ResourceTrackingManagerTest.kt
@@ -24,13 +24,13 @@ import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
 import com.netflix.spinnaker.swabbie.test.TestResource
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
-import com.nhaarman.mockito_kotlin.argWhere
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.verify
-import java.time.Clock
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import java.time.Clock
 
 object ResourceTrackingManagerTest {
   private val resourceTrackingRepository = mock<ResourceTrackingRepository>()

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/notifications/NotificationSenderTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/notifications/NotificationSenderTest.kt
@@ -32,24 +32,24 @@ import com.netflix.spinnaker.swabbie.repository.ResourceTrackingRepository
 import com.netflix.spinnaker.swabbie.test.InMemoryNotificationQueue
 import com.netflix.spinnaker.swabbie.test.TestResource
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.never
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
-import java.time.Clock
-import java.time.Instant
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
 import strikt.assertions.isNotEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
+import java.time.Clock
+import java.time.Instant
 
 object NotificationSenderTest {
   private val notifier = mock<Notifier>()
@@ -87,7 +87,7 @@ object NotificationSenderTest {
 
   @BeforeEach
   fun setup() {
-    whenever(dynamicConfigService.getConfig(any<Class<*>>(), any(), any())) doReturn 2
+    whenever(dynamicConfigService.getConfig(any<Class<Int>>(), any(), any())) doReturn 2
     whenever(discoveryStatusListener.isEnabled) doReturn true
   }
 

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkProcessorTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkProcessorTest.kt
@@ -25,19 +25,19 @@ import com.netflix.spinnaker.swabbie.test.InMemoryWorkQueue
 import com.netflix.spinnaker.swabbie.test.NoopCacheStatus
 import com.netflix.spinnaker.swabbie.test.TestResource
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.never
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
-import java.time.Clock
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import strikt.api.expectThat
 import strikt.assertions.isFalse
 import strikt.assertions.isTrue
+import java.time.Clock
 
 object WorkProcessorTest {
   private val workConfiguration1 = WorkConfigurationTestHelper

--- a/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManagerTest.kt
+++ b/swabbie-core/src/test/kotlin/com/netflix/spinnaker/swabbie/work/WorkQueueManagerTest.kt
@@ -27,20 +27,20 @@ import com.netflix.spinnaker.kork.test.time.MutableClock
 import com.netflix.spinnaker.swabbie.test.InMemoryWorkQueue
 import com.netflix.spinnaker.swabbie.test.NoopCacheStatus
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.whenever
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.whenever
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.Month
 import java.time.ZoneId
 import java.time.ZoneOffset
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import strikt.api.expectThat
-import strikt.assertions.isFalse
-import strikt.assertions.isTrue
 
 object WorkQueueManagerTest {
 

--- a/swabbie-core/swabbie-core.gradle
+++ b/swabbie-core/swabbie-core.gradle
@@ -16,10 +16,10 @@
 
 dependencies {
   implementation "org.slf4j:jcl-over-slf4j"
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-moniker"
   implementation "net.logstash.logback:logstash-logback-encoder"
-  implementation "com.netflix.spinnaker.kork:kork-moniker"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.fasterxml.jackson.core:jackson-annotations"
   implementation "com.fasterxml.jackson.core:jackson-core"
@@ -30,6 +30,6 @@ dependencies {
   implementation "com.google.guava:guava"
 
   testImplementation project(":swabbie-test")
-  testImplementation "com.netflix.spinnaker.kork:kork-test"
+  testImplementation "io.spinnaker.kork:kork-test"
   testImplementation "io.strikt:strikt-core"
 }

--- a/swabbie-echo/src/test/kotlin/com/netflix/spinnaker/swabbie/echo/EchoNotifierTest.kt
+++ b/swabbie-echo/src/test/kotlin/com/netflix/spinnaker/swabbie/echo/EchoNotifierTest.kt
@@ -22,10 +22,10 @@ import com.netflix.spinnaker.swabbie.model.Summary
 import com.netflix.spinnaker.swabbie.notifications.Notifier
 import com.netflix.spinnaker.swabbie.test.TestResource
 import com.netflix.spinnaker.swabbie.test.WorkConfigurationTestHelper
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 

--- a/swabbie-echo/swabbie-echo.gradle
+++ b/swabbie-echo/swabbie-echo.gradle
@@ -17,8 +17,8 @@
 dependencies {
   implementation project(":swabbie-core")
   implementation project(":swabbie-retrofit")
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-web"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.okhttp:okhttp-apache"

--- a/swabbie-front50/src/test/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategyTest.kt
+++ b/swabbie-front50/src/test/kotlin/com/netflix/spinnaker/swabbie/front50/ApplicationResourceOwnerResolutionStrategyTest.kt
@@ -24,10 +24,10 @@ import com.netflix.spinnaker.swabbie.model.Application
 import com.netflix.spinnaker.swabbie.model.Grouping
 import com.netflix.spinnaker.swabbie.model.GroupingType
 import com.netflix.spinnaker.swabbie.test.TestResource
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 object ApplicationResourceOwnerResolutionStrategyTest {
   private val front50ApplicationCache: InMemoryCache<Application> = mock()

--- a/swabbie-front50/src/test/kotlin/com/netflix/spinnaker/swabbie/front50/Front50ApplicationExclusionPolicyTest.kt
+++ b/swabbie-front50/src/test/kotlin/com/netflix/spinnaker/swabbie/front50/Front50ApplicationExclusionPolicyTest.kt
@@ -26,11 +26,11 @@ import com.netflix.spinnaker.swabbie.model.Application
 import com.netflix.spinnaker.swabbie.model.Grouping
 import com.netflix.spinnaker.swabbie.model.GroupingType
 import com.netflix.spinnaker.swabbie.test.TestResource
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 object Front50ApplicationExclusionPolicyTest {
   private val front50ApplicationCache: InMemoryCache<Application> = mock()

--- a/swabbie-front50/swabbie-front50.gradle
+++ b/swabbie-front50/swabbie-front50.gradle
@@ -17,8 +17,8 @@
 dependencies {
   implementation project(":swabbie-core")
   implementation project(":swabbie-retrofit")
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-web"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.squareup.retrofit:retrofit"
   implementation "com.squareup.okhttp:okhttp-apache"

--- a/swabbie-orca/swabbie-orca.gradle
+++ b/swabbie-orca/swabbie-orca.gradle
@@ -17,9 +17,9 @@
 dependencies {
   implementation project(":swabbie-core")
   implementation project(":swabbie-retrofit")
-  implementation "com.netflix.spinnaker.kork:kork-core"
-  implementation "com.netflix.spinnaker.kork:kork-web"
-  implementation "com.netflix.spinnaker.kork:kork-moniker"
+  implementation "io.spinnaker.kork:kork-core"
+  implementation "io.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-moniker"
   implementation "net.logstash.logback:logstash-logback-encoder"
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client"
   implementation "com.squareup.retrofit:retrofit"

--- a/swabbie-redis/swabbie-redis.gradle
+++ b/swabbie-redis/swabbie-redis.gradle
@@ -18,11 +18,11 @@ dependencies {
   implementation project(":swabbie-core")
 
   implementation "redis.clients:jedis"
-  implementation "com.netflix.spinnaker.kork:kork-jedis"
-  implementation "com.netflix.spinnaker.kork:kork-test"
+  implementation "io.spinnaker.kork:kork-jedis"
+  implementation "io.spinnaker.kork:kork-test"
   implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
 
-  testImplementation "com.netflix.spinnaker.kork:kork-jedis-test"
+  testImplementation "io.spinnaker.kork:kork-jedis-test"
   testImplementation project(":swabbie-test")
   testImplementation("io.strikt:strikt-core")
 }

--- a/swabbie-retrofit/swabbie-retrofit.gradle
+++ b/swabbie-retrofit/swabbie-retrofit.gradle
@@ -20,6 +20,6 @@ dependencies {
   implementation "com.squareup.okhttp:okhttp-apache"
   implementation "com.squareup.okhttp:okhttp-urlconnection"
   implementation "com.squareup.retrofit:converter-jackson"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-web"
   implementation "io.reactivex:rxjava"
 }

--- a/swabbie-web/swabbie-web.gradle
+++ b/swabbie-web/swabbie-web.gradle
@@ -30,7 +30,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.springframework.boot:spring-boot-starter-data-rest"
-  implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "io.spinnaker.kork:kork-web"
   implementation project(":swabbie-aws")
   implementation project(":swabbie-clouddriver")
   implementation project(":swabbie-core")
@@ -38,5 +38,5 @@ dependencies {
   implementation project(":swabbie-front50")
   implementation project(":swabbie-redis")
   implementation project(":swabbie-test")
-  runtimeOnly "com.netflix.spinnaker.kork:kork-runtime"
+  runtimeOnly "io.spinnaker.kork:kork-runtime"
 }


### PR DESCRIPTION
Swabbie was unbuildable due to Bintray dependencies. This PR makes the project buildable again.

The build and release scripts in `.github/workflows/` may still need som love by someone that knows the current release process...