### PR TITLE
chore(mergify): stop using strict mode in mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,8 @@
+queue_rules:
+  - name: default
+    conditions:
+      - status-success=build
+
 pull_request_rules:
   - name: Automatically merge on CI success and review
     conditions:
@@ -6,9 +11,9 @@ pull_request_rules:
       - "label=ready to merge"
       - "approved-reviews-by=@oss-approvers"
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
+        name: default
       label:
         add: ["auto merged"]
   - name: Automatically merge release branch changes on CI success and release manager review
@@ -18,23 +23,9 @@ pull_request_rules:
       - "label=ready to merge"
       - "approved-reviews-by=@release-managers"
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
-      label:
-        add: ["auto merged"]
-  # This rule exists to handle release branches that are still building using Travis CI instead of
-  # using Github actions. It can be deleted once all active release branches are running Github actions.
-  - name: Automatically merge release branch changes on Travis CI success and release manager review
-    conditions:
-      - base~=^release-
-      - status-success=continuous-integration/travis-ci/pr
-      - "label=ready to merge"
-      - "approved-reviews-by=@release-managers"
-    actions:
-      merge:
-        method: squash
-        strict: smart
+        name: default
       label:
         add: ["auto merged"]
   - name: Automatically merge PRs from maintainers on CI success and review
@@ -44,26 +35,26 @@ pull_request_rules:
       - "label=ready to merge"
       - "author=@oss-approvers"
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
+        name: default
       label:
         add: ["auto merged"]
   - name: Automatically merge autobump PRs on CI success
     conditions:
-      - base=master
+      - base~=^(master|release-)
       - status-success=build
       - "label~=autobump-*"
       - "author:spinnakerbot"
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart
+        name: default
       label:
         add: ["auto merged"]
   - name: Request reviews for autobump PRs on CI failure
     conditions:
-      - base=master
+      - base~=^(master|release-)
       - status-failure=build
       - "label~=autobump-*"
       - base=master


### PR DESCRIPTION
since it's deprecated.  See https://blog.mergify.com/strict-mode-deprecation/