### PR TITLE
feat(auth): Support for spinnaker user

### DIFF
--- a/swabbie-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
+++ b/swabbie-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
@@ -21,6 +21,7 @@ import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor
 import com.netflix.spinnaker.swabbie.clouddriver.CloudDriverService
+import com.netflix.spinnaker.swabbie.retrofit.SwabbieRetrofitConfiguration
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -28,10 +29,11 @@ import org.springframework.context.annotation.Import
 import retrofit.Endpoint
 import retrofit.Endpoints
 import retrofit.RestAdapter
+import retrofit.client.Client
 import retrofit.converter.JacksonConverter
 
 @Configuration
-@Import(RetrofitConfiguration::class)
+@Import(SwabbieRetrofitConfiguration::class)
 open class ClouddriverConfiguration {
   @Bean
   open fun clouddriverEndpoint(@Value("\${clouddriver.base-url}") clouddriverBaseUrl: String) = Endpoints.newFixedEndpoint(clouddriverBaseUrl)
@@ -40,13 +42,13 @@ open class ClouddriverConfiguration {
   open fun clouddriverService(
     clouddriverEndpoint: Endpoint,
     objectMapper: ObjectMapper,
-    clientProvider: OkHttpClientProvider,
+    retrofitClient: Client,
     spinnakerRequestInterceptor: SpinnakerRequestInterceptor,
     retrofitLogLevel: RestAdapter.LogLevel
   ) = RestAdapter.Builder()
     .setRequestInterceptor(spinnakerRequestInterceptor)
     .setEndpoint(clouddriverEndpoint)
-    .setClient(Ok3Client(clientProvider.getClient(DefaultServiceEndpoint("clouddriver", clouddriverEndpoint.url))))
+    .setClient(retrofitClient)
     .setLogLevel(retrofitLogLevel)
     .setConverter(JacksonConverter(objectMapper))
     .build()

--- a/swabbie-echo/src/main/kotlin/com/netflix/spinnaker/config/EchoConfiguration.kt
+++ b/swabbie-echo/src/main/kotlin/com/netflix/spinnaker/config/EchoConfiguration.kt
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.jakewharton.retrofit.Ok3Client
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.swabbie.echo.EchoService
+import com.netflix.spinnaker.swabbie.retrofit.SwabbieRetrofitConfiguration
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -30,11 +31,12 @@ import retrofit.Endpoint
 import retrofit.Endpoints
 import retrofit.RequestInterceptor
 import retrofit.RestAdapter
+import retrofit.client.Client
 import retrofit.converter.JacksonConverter
 
 @Configuration
 @ComponentScan("com.netflix.spinnaker.swabbie.echo")
-@Import(RetrofitConfiguration::class)
+@Import(SwabbieRetrofitConfiguration::class)
 open class EchoConfiguration {
   private val log = LoggerFactory.getLogger(javaClass)
 
@@ -45,13 +47,13 @@ open class EchoConfiguration {
   open fun echoService(
     echoEndpoint: Endpoint,
     objectMapper: ObjectMapper,
-    clientProvider: OkHttpClientProvider,
+    retrofitClient: Client,
     spinnakerRequestInterceptor: RequestInterceptor,
     retrofitLogLevel: RestAdapter.LogLevel
   ) = RestAdapter.Builder()
     .setRequestInterceptor(spinnakerRequestInterceptor)
     .setEndpoint(echoEndpoint)
-    .setClient(Ok3Client(clientProvider.getClient(DefaultServiceEndpoint("echo", echoEndpoint.url))))
+    .setClient(retrofitClient)
     .setLogLevel(retrofitLogLevel)
     .setConverter(JacksonConverter(objectMapper))
     .build()

--- a/swabbie-front50/src/main/kotlin/com/netflix/spinnaker/config/Front50Configuration.kt
+++ b/swabbie-front50/src/main/kotlin/com/netflix/spinnaker/config/Front50Configuration.kt
@@ -17,10 +17,9 @@
 package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.jakewharton.retrofit.Ok3Client
-import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.okhttp.SpinnakerRequestInterceptor
 import com.netflix.spinnaker.swabbie.front50.Front50Service
+import com.netflix.spinnaker.swabbie.retrofit.SwabbieRetrofitConfiguration
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
@@ -29,10 +28,11 @@ import org.springframework.context.annotation.Import
 import retrofit.Endpoint
 import retrofit.Endpoints
 import retrofit.RestAdapter
+import retrofit.client.Client
 import retrofit.converter.JacksonConverter
 
 @Configuration
-@Import(RetrofitConfiguration::class)
+@Import(SwabbieRetrofitConfiguration::class)
 @ComponentScan("com.netflix.spinnaker.swabbie.front50")
 open class Front50Configuration {
   @Bean
@@ -42,13 +42,13 @@ open class Front50Configuration {
   open fun front50Service(
     front50Endpoint: Endpoint,
     objectMapper: ObjectMapper,
-    clientProvider: OkHttpClientProvider,
+    retrofitClient: Client,
     spinnakerRequestInterceptor: SpinnakerRequestInterceptor,
     retrofitLogLevel: RestAdapter.LogLevel
   ): Front50Service = RestAdapter.Builder()
     .setRequestInterceptor(spinnakerRequestInterceptor)
     .setEndpoint(front50Endpoint)
-    .setClient(Ok3Client(clientProvider.getClient(DefaultServiceEndpoint("front50", front50Endpoint.url))))
+    .setClient(retrofitClient)
     .setLogLevel(retrofitLogLevel)
     .setConverter(JacksonConverter(objectMapper))
     .build()

--- a/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/config/OrcaConfiguration.kt
+++ b/swabbie-orca/src/main/kotlin/com/netflix/spinnaker/config/OrcaConfiguration.kt
@@ -17,10 +17,9 @@
 package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.jakewharton.retrofit.Ok3Client
-import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.swabbie.orca.OrcaService
 import com.netflix.spinnaker.swabbie.orca.tagging.OrcaTaggingService
+import com.netflix.spinnaker.swabbie.retrofit.SwabbieRetrofitConfiguration
 import com.netflix.spinnaker.swabbie.tagging.TaggingService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -31,10 +30,11 @@ import retrofit.Endpoint
 import retrofit.Endpoints
 import retrofit.RequestInterceptor
 import retrofit.RestAdapter
+import retrofit.client.Client
 import retrofit.converter.JacksonConverter
 
 @Configuration
-@Import(RetrofitConfiguration::class)
+@Import(SwabbieRetrofitConfiguration::class)
 @ComponentScan("com.netflix.spinnaker.swabbie.orca")
 open class OrcaConfiguration {
   @Bean
@@ -45,14 +45,14 @@ open class OrcaConfiguration {
   open fun orcaService(
     orcaEndpoint: Endpoint,
     objectMapper: ObjectMapper,
-    clientProvider: OkHttpClientProvider,
+    retrofitClient: Client,
     spinnakerRequestInterceptor: RequestInterceptor,
     retrofitLogLevel: RestAdapter.LogLevel
   ): OrcaService =
     RestAdapter.Builder()
       .setRequestInterceptor(spinnakerRequestInterceptor)
       .setEndpoint(orcaEndpoint)
-      .setClient(Ok3Client(clientProvider.getClient(DefaultServiceEndpoint("orca", orcaEndpoint.url))))
+      .setClient(retrofitClient)
       .setLogLevel(retrofitLogLevel)
       .setConverter(JacksonConverter(objectMapper))
       .build()

--- a/swabbie-retrofit/swabbie-retrofit.gradle
+++ b/swabbie-retrofit/swabbie-retrofit.gradle
@@ -22,4 +22,5 @@ dependencies {
   implementation "com.squareup.retrofit:converter-jackson"
   implementation "io.spinnaker.kork:kork-web"
   implementation "io.reactivex:rxjava"
+  implementation project(":swabbie-core")
 }


### PR DESCRIPTION
The `X-SPINNAKER-USER` header will be set to the value of `ok-http-client.spinnaker-user` (defaulting to `swabbie@spinnaker.io`), and `X-SPINNAKER-ACCOUNTS` will be contain all the accounts that are configured in Swabbie. This is already supported for the Edda client, but not for calls to Echo, Front50, Orca or Clouddriver, so this PR just change the different service classes to use the same retrofit/okHttpClient as Edda and adds the `X-SPINNAKER-ACCOUNTS` header as well. These headers are needed if you are trying to clean up any protected AWS accounts.