### PR TITLE
chore(dependencies): bump korkVersion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-korkVersion=7.169.0
+korkVersion=7.169.1
 kotlinVersion=1.6.21
 org.gradle.parallel=true
 spinnakerGradleVersion=8.25.0


### PR DESCRIPTION
The release-1.30.x branch didn't exist when the automation in kork tried to make this, so doing it manually.