### PR TITLE
fix(aws): Change default region to us-east-1

### DIFF
--- a/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
+++ b/swabbie-aws/src/main/kotlin/com/netflix/spinnaker/config/AwsConfiguration.kt
@@ -47,7 +47,7 @@ import org.springframework.context.annotation.Import
 @ComponentScan(basePackages = ["com.netflix.spinnaker.swabbie.aws"])
 @Import(BastionConfig::class)
 open class AwsConfiguration {
-  private val defaultRegion = "us-west-2" // TODO: (Jeyrs) Make configurable
+  private val defaultRegion = "us-east-1" // TODO: (Jeyrs) Make configurable
 
   // AWS object mapper ensures edda and vanilla aws responses are the same
   @Bean


### PR DESCRIPTION
Regional STS endpoints can be turned on or off, so there is no guarantee that `us-west-2` is enabled. However, `us-east-1` is special as it is the only regional endpoint that can't be turned off. This fixes the following error:

```
com.amazonaws.services.securitytoken.model.RegionDisabledException: STS is not activated in this region for account:01234567890. Your account administrator can activate STS in this region using the IAM Console.
```