### PR TITLE
fix(core): Add another date format to the date parser

### DIFF
--- a/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Dates.kt
+++ b/swabbie-core/src/main/kotlin/com/netflix/spinnaker/swabbie/Dates.kt
@@ -26,6 +26,7 @@ class Dates {
     private val formats: List<DateTimeFormatter> = listOf(
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSS'Z'"),
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ"),
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"),
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"),
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"),
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS"),


### PR DESCRIPTION
Swabbie started failing when parsing AMI image timestamp. Adding another pattern to the list of supported formats fixed the issue.