### PR TITLE
fix(ubuntu): add commands so apt-get can install libc

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && apt-get -y install curl openjdk-17-jre-headless wget
 RUN adduser --system --uid 10111 --group spinnaker
 COPY swabbie-web/build/install/swabbie /opt/swabbie
 RUN mkdir -p /opt/swabbie/plugins && chown -R spinnaker:nogroup /opt/swabbie/plugins


### PR DESCRIPTION
specifically:
```
rm /var/lib/dpkg/info/libc-bin.* && apt-get clean
```
to fix errors like
```
#9 104.3 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
#9 104.4 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#9 104.8 Segmentation fault (core dumped)
#9 104.9 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#9 105.3 Segmentation fault (core dumped)
#9 105.3 dpkg: error processing package libc-bin (--configure):
```
from https://github.com/spinnaker/swabbie/actions/runs/13294125002/job/37121792563?pr=697

suggestion from https://stackoverflow.com/a/78107622

similar to https://github.com/spinnaker/orca/pull/4834